### PR TITLE
Add date input with fallback for player birthdate

### DIFF
--- a/js/date-fallback.js
+++ b/js/date-fallback.js
@@ -1,0 +1,20 @@
+(function($){
+    $(function(){
+        var $fields = $('input.mvpclub-date-field');
+        if(!$fields.length) return;
+        var test = document.createElement('input');
+        test.setAttribute('type','date');
+        if(test.type !== 'date') {
+            $fields.each(function(){
+                var $input = $(this);
+                var textVal = $input.data('date-text') || '';
+                if(textVal) {
+                    $input.val(textVal);
+                }
+                $input.attr('type','text').datepicker({
+                    dateFormat: 'dd.mm.yy'
+                });
+            });
+        }
+    });
+})(jQuery);


### PR DESCRIPTION
## Summary
- use `<input type="date">` for the birthdate field
- add a JS fallback using jQuery UI datepicker for browsers without native date inputs
- validate and convert birthdate before saving

## Testing
- `node --check js/date-fallback.js`
- `php -l players.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68648263458483319865787961800b13