### PR TITLE
Fix encoding for player field labels

### DIFF
--- a/players.php
+++ b/players.php
@@ -27,10 +27,10 @@ function mvpclub_player_fields() {
     return array(
         'birthdate'   => 'Geburtsdatum',
         'birthplace'  => 'Geburtsort',
-        'height'      => 'Gr\xC3\xB6\xC3\x9Fe',
-        'nationality' => 'Nationalit\xC3\xA4t',
+        'height'      => 'Größe',
+        'nationality' => 'Nationalität',
         'position'    => 'Position',
-        'foot'        => 'F\xC3\xBC\xC3\x9F',
+        'foot'        => 'Fuß',
         'agent'       => 'Berater',
         'club'        => 'Verein',
     );


### PR DESCRIPTION
## Summary
- use real UTF-8 strings in player field labels

## Testing
- `php -l players.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68648274cd6c83318d5d0e4a0b35b203