### PR TITLE
Add player image field

### DIFF
--- a/assets/player-image.js
+++ b/assets/player-image.js
@@ -1,0 +1,28 @@
+jQuery(function($){
+    var frame;
+    $(document).on('click', '.mvpclub-player-image-select', function(e){
+        e.preventDefault();
+        if(frame){
+            frame.open();
+            return;
+        }
+        frame = wp.media({
+            title: 'Bild auswählen',
+            button: { text: 'Auswählen' },
+            library: { type: 'image' },
+            multiple: false
+        });
+        frame.on('select', function(){
+            var attachment = frame.state().get('selection').first().toJSON();
+            $('#mvpclub-player-image').val(attachment.id);
+            $('.mvpclub-player-image-preview').html('<img src="'+attachment.sizes.thumbnail.url+'" style="max-width:150px;height:auto;" />');
+        });
+        frame.open();
+    });
+
+    $(document).on('click', '.mvpclub-player-image-remove', function(e){
+        e.preventDefault();
+        $('#mvpclub-player-image').val('');
+        $('.mvpclub-player-image-preview').empty();
+    });
+});


### PR DESCRIPTION
## Summary
- allow storing a custom image for each player
- register the new meta field and expose it to REST
- update player meta box to pick/remove an image
- add JS helper to open the media library
- display the custom player image in frontend and admin list

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68648d69f4048331af575891ec742845