### PR TITLE
Add radar chart preview for admin

### DIFF
--- a/assets/radar-preview.js
+++ b/assets/radar-preview.js
@@ -1,0 +1,43 @@
+(function($){
+    $(function(){
+        var canvas = document.getElementById('mvpclub_radar_preview');
+        if(!canvas){return;}
+        var labelInputs = [], valueInputs = [];
+        for(var i=0;i<6;i++){
+            labelInputs[i] = $('input[name="radar_chart_label'+i+'"]');
+            valueInputs[i] = $('input[name="radar_chart_value'+i+'"]');
+        }
+        function collect(){
+            var labels = labelInputs.map(function($el){ return $el.val(); });
+            var values = valueInputs.map(function($el){ return parseInt($el.val(),10) || 0; });
+            return {labels: labels, values: values};
+        }
+        var data = collect();
+        var chart = new Chart(canvas, {
+            type: 'radar',
+            data: {
+                labels: data.labels,
+                datasets: [{
+                    label: 'Vorschau',
+                    data: data.values,
+                    backgroundColor: 'rgba(54,162,235,0.2)',
+                    borderColor: 'rgba(54,162,235,1)'
+                }]
+            },
+            options: {
+                scales: {
+                    r: {min: 0, max: 100, beginAtZero: true}
+                }
+            }
+        });
+        function update(){
+            var d = collect();
+            chart.data.labels = d.labels;
+            chart.data.datasets[0].data = d.values;
+            chart.update();
+        }
+        labelInputs.concat(valueInputs).forEach(function($el){
+            $el.on('input', update);
+        });
+    });
+})(jQuery);

--- a/players.php
+++ b/players.php
@@ -124,6 +124,16 @@ function mvpclub_player_admin_scripts($hook) {
         array(),
         filemtime(plugin_dir_path(__FILE__) . 'assets/nationality-autocomplete.css')
     );
+
+    wp_enqueue_script('chartjs', 'https://cdn.jsdelivr.net/npm/chart.js');
+
+    wp_enqueue_script(
+        'mvpclub-radar-preview',
+        plugins_url('assets/radar-preview.js', __FILE__),
+        array('jquery', 'chartjs'),
+        filemtime(plugin_dir_path(__FILE__) . 'assets/radar-preview.js'),
+        true
+    );
 }
 
 function mvpclub_player_meta_box($post) {
@@ -143,6 +153,7 @@ function mvpclub_player_meta_box($post) {
                 echo '<td><input type="range" name="radar_chart_value' . $i . '" min="0" max="100" value="' . esc_attr($v) . '" oninput="this.nextElementSibling.value=this.value" />';
                 echo '<output>' . esc_html($v) . '</output></td></tr>';
             }
+            echo '<tr><td colspan="2"><canvas id="mvpclub_radar_preview"></canvas></td></tr>';
         } else {
             echo '<tr><th><label for="' . esc_attr($key) . '">' . esc_html($label) . '</label></th>';
             echo '<td><input type="text" name="' . esc_attr($key) . '" id="' . esc_attr($key) . '" value="' . esc_attr($value) . '" class="regular-text" /></td></tr>';


### PR DESCRIPTION
## Summary
- add a canvas preview row for radar chart inputs
- draw live preview chart using new `assets/radar-preview.js`
- enqueue Chart.js and the preview script in `mvpclub_player_admin_scripts`

## Testing
- `php -l players.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68648d74e198833182827d216a93fabe