### PR TITLE
Add advanced player meta sections

### DIFF
--- a/players.php
+++ b/players.php
@@ -64,16 +64,20 @@ function mvpclub_migrate_player_cpt() {
  */
 function mvpclub_player_fields() {
     return array(
-        'birthdate'   => 'Geburtsdatum',
-        'birthplace'  => 'Geburtsort',
-        'height'      => 'Größe',
-        'nationality' => 'Nationalität',
-        'position'    => 'Position',
-        'foot'        => 'Fuß',
-        'agent'       => 'Berater',
-        'club'        => 'Verein',
-        'image'       => 'Bild',
-        'radar_chart' => 'Radar Chart',
+        'birthdate'        => 'Geburtsdatum',
+        'birthplace'       => 'Geburtsort',
+        'height'           => 'Größe',
+        'nationality'      => 'Nationalität',
+        'position'         => 'Position',
+        'detail_position'  => 'Detailposition',
+        'foot'             => 'Fuß',
+        'agent'            => 'Berater',
+        'club'             => 'Verein',
+        'market_value'     => 'Marktwert',
+        'rating'           => 'Bewertung',
+        'performance_data' => 'Leistungsdaten',
+        'image'            => 'Bild',
+        'radar_chart'      => 'Radar Chart',
     );
 }
 
@@ -87,7 +91,7 @@ add_action('init', function() {
             'show_in_rest' => true,
             'auth_callback'=> function() { return current_user_can('edit_posts'); },
         );
-        if ($key === 'radar_chart') {
+        if ($key === 'radar_chart' || $key === 'performance_data') {
             $args['type'] = 'string';
             $args['sanitize_callback'] = null;
         } elseif ($key === 'image') {
@@ -143,25 +147,39 @@ function mvpclub_player_admin_scripts($hook) {
         filemtime(plugin_dir_path(__FILE__) . 'assets/player-image.js'),
         true
     );
+
+    wp_enqueue_script(
+        'chartjs',
+        plugins_url('assets/chart.js', __FILE__),
+        array(),
+        filemtime(plugin_dir_path(__FILE__) . 'assets/chart.js'),
+        true
+    );
 }
 
 function mvpclub_player_meta_box($post) {
     wp_nonce_field('mvpclub_save_player', 'mvpclub_player_nonce');
-    echo '<table class="form-table">';
-    foreach (mvpclub_player_fields() as $key => $label) {
-        $value = get_post_meta($post->ID, $key, true);
-        if ($key === 'radar_chart') {
-            $chart = json_decode($value, true);
-            $labels = isset($chart['labels']) ? (array) $chart['labels'] : array_fill(0, 6, '');
-            $values = isset($chart['values']) ? (array) $chart['values'] : array_fill(0, 6, 0);
-            echo '<tr><th colspan="2">' . esc_html($label) . '</th></tr>';
-            for ($i = 0; $i < 6; $i++) {
-                $l = isset($labels[$i]) ? $labels[$i] : '';
-                $v = isset($values[$i]) ? $values[$i] : 0;
-                echo '<tr><td><input type="text" name="radar_chart_label' . $i . '" value="' . esc_attr($l) . '" placeholder="Label" /></td>';
-                echo '<td><input type="range" name="radar_chart_value' . $i . '" min="0" max="100" value="' . esc_attr($v) . '" oninput="this.nextElementSibling.value=this.value" />';
-                echo '<output>' . esc_html($v) . '</output></td></tr>';
+
+    $fields = mvpclub_player_fields();
+    $values = array();
+    foreach ($fields as $k => $l) {
+        $values[$k] = get_post_meta($post->ID, $k, true);
+    }
+
+    echo '<h2>Information</h2><table class="form-table">';
+    $info_keys = array('birthdate','birthplace','height','nationality','position','detail_position','foot','agent','club','market_value','image');
+    foreach ($info_keys as $key) {
+        $label = $fields[$key];
+        $value = isset($values[$key]) ? $values[$key] : '';
+        if ($key === 'detail_position') {
+            $selected = $value ? explode(',', $value) : array();
+            $options = array('TW','LV','IV','RV','DM','ZM','OM','LA','RA','ST');
+            echo '<tr><th><label for="detail_position">' . esc_html($label) . '</label></th><td><select name="detail_position[]" id="detail_position" multiple size="5">';
+            foreach ($options as $op) {
+                $sel = in_array($op, $selected) ? ' selected' : '';
+                echo '<option value="' . esc_attr($op) . '"' . $sel . '>' . esc_html($op) . '</option>';
             }
+            echo '</select></td></tr>';
         } elseif ($key === 'image') {
             $img_id  = intval($value);
             $preview = $img_id ? wp_get_attachment_image_src($img_id, 'thumbnail') : false;
@@ -181,6 +199,82 @@ function mvpclub_player_meta_box($post) {
         }
     }
     echo '</table>';
+
+    echo '<h2>Bewertung</h2><table class="form-table">';
+    $rating = isset($values['rating']) ? $values['rating'] : '';
+    echo '<tr><th><label for="rating">' . esc_html($fields['rating']) . '</label></th><td><input type="range" name="rating" id="rating" min="1" max="5" step="0.5" value="' . esc_attr($rating) . '" oninput="this.nextElementSibling.value=this.value" /> <output>' . esc_html($rating) . '</output></td></tr>';
+    echo '</table>';
+
+    echo '<h2>Leistungsdaten</h2>';
+    $perf = json_decode($values['performance_data'], true);
+    if (!is_array($perf)) { $perf = array(); }
+    echo '<table id="performance-data-table" class="widefat"><thead><tr><th>Saison</th><th>Wettbewerb</th><th>Spiele</th><th>Tore</th><th>Assists</th><th>Minuten</th><th></th></tr></thead><tbody>';
+    foreach ($perf as $row) {
+        echo '<tr>';
+        echo '<td><input type="text" name="perf_saison[]" value="' . esc_attr($row['Saison'] ?? '') . '" /></td>';
+        echo '<td><input type="text" name="perf_competition[]" value="' . esc_attr($row['Wettbewerb'] ?? '') . '" /></td>';
+        echo '<td><input type="number" name="perf_games[]" value="' . esc_attr($row['Spiele'] ?? '') . '" /></td>';
+        echo '<td><input type="number" name="perf_goals[]" value="' . esc_attr($row['Tore'] ?? '') . '" /></td>';
+        echo '<td><input type="number" name="perf_assists[]" value="' . esc_attr($row['Assists'] ?? '') . '" /></td>';
+        echo '<td><input type="number" name="perf_minutes[]" value="' . esc_attr($row['Minuten'] ?? '') . '" /></td>';
+        echo '<td><button class="button remove-performance-row">X</button></td>';
+        echo '</tr>';
+    }
+    echo '</tbody></table>';
+    echo '<p><button type="button" class="button" id="add-performance-row">Zeile hinzufügen</button></p>';
+
+    echo '<h2>Radar</h2><table class="form-table">';
+    $chart = json_decode($values['radar_chart'], true);
+    $labels = isset($chart['labels']) ? (array) $chart['labels'] : array_fill(0, 6, '');
+    $values_radar = isset($chart['values']) ? (array) $chart['values'] : array_fill(0, 6, 0);
+    for ($i = 0; $i < 6; $i++) {
+        $l = isset($labels[$i]) ? $labels[$i] : '';
+        $v = isset($values_radar[$i]) ? $values_radar[$i] : 0;
+        echo '<tr><td><input type="text" name="radar_chart_label' . $i . '" value="' . esc_attr($l) . '" placeholder="Label" /></td>';
+        echo '<td><input type="range" name="radar_chart_value' . $i . '" min="0" max="100" value="' . esc_attr($v) . '" oninput="this.nextElementSibling.value=this.value" />';
+        echo '<output>' . esc_html($v) . '</output></td></tr>';
+    }
+    echo '<tr><td colspan="2"><canvas id="mvpclub-radar-preview" width="300" height="300"></canvas></td></tr>';
+    echo '</table>';
+
+    ?>
+    <script>
+    jQuery(function($){
+        $('#add-performance-row').on('click', function(e){
+            e.preventDefault();
+            var row = $('<tr>\
+                <td><input type="text" name="perf_saison[]" /></td>\
+                <td><input type="text" name="perf_competition[]" /></td>\
+                <td><input type="number" name="perf_games[]" /></td>\
+                <td><input type="number" name="perf_goals[]" /></td>\
+                <td><input type="number" name="perf_assists[]" /></td>\
+                <td><input type="number" name="perf_minutes[]" /></td>\
+                <td><button class="button remove-performance-row">X</button></td>\
+            </tr>');
+            $('#performance-data-table tbody').append(row);
+        });
+        $(document).on('click', '.remove-performance-row', function(e){
+            e.preventDefault();
+            $(this).closest('tr').remove();
+        });
+
+        var ctx = document.getElementById('mvpclub-radar-preview');
+        var radarChart;
+        function renderRadar(){
+            if(!ctx){return;}
+            var labels = [], data = [];
+            for(var i=0;i<6;i++){
+                labels.push($('[name="radar_chart_label'+i+'"]').val());
+                data.push(parseInt($('[name="radar_chart_value'+i+'"]').val()) || 0);
+            }
+            if(radarChart){radarChart.destroy();}
+            radarChart = new Chart(ctx,{type:'radar',data:{labels:labels,datasets:[{label:'Werte',data:data,backgroundColor:'rgba(54,162,235,0.2)',borderColor:'rgba(54,162,235,1)'}]},options:{scales:{r:{min:0,max:100,beginAtZero:true}}});
+        }
+        $('[name^="radar_chart_label"], [name^="radar_chart_value"]').on('input', renderRadar);
+        renderRadar();
+    });
+    </script>
+    <?php
 }
 
 /**
@@ -208,6 +302,39 @@ add_action('save_post_mvpclub-spieler', function($post_id) {
             } else {
                 delete_post_meta($post_id, 'image');
             }
+        } elseif ($key === 'detail_position') {
+            if (isset($_POST['detail_position']) && is_array($_POST['detail_position'])) {
+                $val = implode(',', array_map('sanitize_text_field', $_POST['detail_position']));
+                update_post_meta($post_id, 'detail_position', $val);
+            } else {
+                delete_post_meta($post_id, 'detail_position');
+            }
+        } elseif ($key === 'rating') {
+            $rating = isset($_POST['rating']) ? floatval($_POST['rating']) : '';
+            if ($rating !== '') {
+                update_post_meta($post_id, 'rating', $rating);
+            } else {
+                delete_post_meta($post_id, 'rating');
+            }
+        } elseif ($key === 'performance_data') {
+            $perf = array();
+            if (isset($_POST['perf_saison'])) {
+                $count = count($_POST['perf_saison']);
+                for ($i = 0; $i < $count; $i++) {
+                    $row = array(
+                        'Saison'     => sanitize_text_field($_POST['perf_saison'][$i]),
+                        'Wettbewerb' => sanitize_text_field($_POST['perf_competition'][$i]),
+                        'Spiele'     => intval($_POST['perf_games'][$i]),
+                        'Tore'       => intval($_POST['perf_goals'][$i]),
+                        'Assists'    => intval($_POST['perf_assists'][$i]),
+                        'Minuten'    => intval($_POST['perf_minutes'][$i]),
+                    );
+                    if (array_filter($row)) {
+                        $perf[] = $row;
+                    }
+                }
+            }
+            update_post_meta($post_id, 'performance_data', wp_json_encode($perf));
         } elseif (isset($_POST[$key])) {
             update_post_meta($post_id, $key, sanitize_text_field($_POST[$key]));
         }


### PR DESCRIPTION
## Summary
- expand player fields to include more meta data
- load Chart.js in admin
- restructure player meta box with new sections
- handle rating, performance table and detail position on save

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864e232cf6483319b08cd76bbe57719