### PR TITLE
Add live radar chart preview in player meta box

### DIFF
--- a/assets/radar-editor.js
+++ b/assets/radar-editor.js
@@ -1,4 +1,5 @@
 jQuery(function($){
+    'use strict';
     var ctx = document.getElementById('mvpclub-radar-preview');
     if(!ctx || typeof Chart === 'undefined'){return;}
 

--- a/assets/radar-editor.js
+++ b/assets/radar-editor.js
@@ -1,0 +1,38 @@
+jQuery(function($){
+    var ctx = document.getElementById('mvpclub-radar-preview');
+    if(!ctx || typeof Chart === 'undefined'){return;}
+
+    function getLabels(){
+        return $('input[name^="radar_chart_label"]').map(function(){
+            return $(this).val();
+        }).get();
+    }
+    function getValues(){
+        return $('input[name^="radar_chart_value"]').map(function(){
+            var v = parseInt($(this).val(),10);
+            return isNaN(v) ? 0 : v;
+        }).get();
+    }
+
+    var chart = new Chart(ctx, {
+        type: 'radar',
+        data: {
+            labels: getLabels(),
+            datasets: [{
+                label: 'Vorschau',
+                data: getValues(),
+                backgroundColor: 'rgba(54,162,235,0.2)',
+                borderColor: 'rgba(54,162,235,1)'
+            }]
+        },
+        options: {
+            scales: { r: { min: 0, max: 100, beginAtZero: true } }
+        }
+    });
+
+    $('input[name^="radar_chart_label"], input[name^="radar_chart_value"]').on('input change', function(){
+        chart.data.labels = getLabels();
+        chart.data.datasets[0].data = getValues();
+        chart.update();
+    });
+});

--- a/players.php
+++ b/players.php
@@ -143,6 +143,22 @@ function mvpclub_player_admin_scripts($hook) {
         filemtime(plugin_dir_path(__FILE__) . 'assets/player-image.js'),
         true
     );
+
+    wp_enqueue_script(
+        'chartjs',
+        plugins_url('assets/chart.js', __FILE__),
+        array(),
+        filemtime(plugin_dir_path(__FILE__) . 'assets/chart.js'),
+        true
+    );
+
+    wp_enqueue_script(
+        'mvpclub-radar-editor',
+        plugins_url('assets/radar-editor.js', __FILE__),
+        array('jquery', 'chartjs'),
+        filemtime(plugin_dir_path(__FILE__) . 'assets/radar-editor.js'),
+        true
+    );
 }
 
 function mvpclub_player_meta_box($post) {
@@ -151,10 +167,11 @@ function mvpclub_player_meta_box($post) {
     foreach (mvpclub_player_fields() as $key => $label) {
         $value = get_post_meta($post->ID, $key, true);
         if ($key === 'radar_chart') {
-            $chart = json_decode($value, true);
+            $chart  = json_decode($value, true);
             $labels = isset($chart['labels']) ? (array) $chart['labels'] : array_fill(0, 6, '');
             $values = isset($chart['values']) ? (array) $chart['values'] : array_fill(0, 6, 0);
             echo '<tr><th colspan="2">' . esc_html($label) . '</th></tr>';
+            echo '<tr><td colspan="2"><canvas id="mvpclub-radar-preview" width="300" height="300"></canvas></td></tr>';
             for ($i = 0; $i < 6; $i++) {
                 $l = isset($labels[$i]) ? $labels[$i] : '';
                 $v = isset($values[$i]) ? $values[$i] : 0;


### PR DESCRIPTION
## Summary
- render a preview canvas in the Radar Chart section of the player meta box
- enqueue Chart.js and a new radar-editor script in admin
- implement radar-editor.js to update the chart as labels/values change

## Testing
- `php -l players.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864e2381bbc83319ac2346408c1533d