### PR TITLE
Update scouting placeholders and statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Das **mvpclub.de Plugin** erweitert WordPress um maßgeschneiderte Funktionen f�
 
 ## Funktionen
 
-- ✅ Shortcodes für dynamische Spielerinfos (z. B. Alter, Position, Leistungsdaten)
+- ✅ Shortcodes für dynamische Spielerinfos (z. B. Alter, Position, Statistik)
 - 📊 Custom Editor.Blöcke für Scoutingberichte und Spielerstatistiken
 - 🔍 Verbesserte SEO-Auszeichnung mit strukturierten Daten
 - 🧠 Optimiert für datengetriebene Fußballinhalte

--- a/assets/player-admin.js
+++ b/assets/player-admin.js
@@ -9,7 +9,7 @@ jQuery(function($){
         return select;
     }
 
-    function addPerformanceRow(){
+    function addStatistikRow(){
         var row = $('<tr>')
             .append('<td><input type="text" name="perf_saison[]" /></td>')
             .append($('<td>').append(competitionSelect()))
@@ -17,16 +17,16 @@ jQuery(function($){
             .append('<td><input type="number" name="perf_goals[]" /></td>')
             .append('<td><input type="number" name="perf_assists[]" /></td>')
             .append('<td><input type="number" name="perf_minutes[]" /></td>')
-            .append('<td><button class="button remove-performance-row">X</button></td>');
-        $('#performance-data-table tbody').append(row);
+            .append('<td><button class="button remove-statistik-row">X</button></td>');
+        $('#statistik-data-table tbody').append(row);
     }
 
-    $(document).on('click', '#add-performance-row', function(e){
+    $(document).on('click', '#add-statistik-row', function(e){
         e.preventDefault();
-        addPerformanceRow();
+        addStatistikRow();
     });
 
-    $(document).on('click', '.remove-performance-row', function(e){
+    $(document).on('click', '.remove-statistik-row', function(e){
         e.preventDefault();
         $(this).closest('tr').remove();
     });

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -56,3 +56,11 @@ add_shortcode('bewertung', function($atts = []) {
     return $rating !== '' ? esc_html($rating) : '';
 });
 
+add_shortcode('statistik', function($atts = []) {
+    $atts = shortcode_atts(['id' => null], $atts);
+    $post_id = $atts['id'] ? intval($atts['id']) : get_the_ID();
+    if (!$post_id) return '';
+    $json = get_post_meta($post_id, 'performance_data', true);
+    return mvpclub_generate_statistik_table($json);
+});
+


### PR DESCRIPTION
## Summary
- rename player placeholders like `[spielername]` and `[detailposition]`
- provide full list of placeholders in scouting reports
- rename "Leistungsdaten" tab to "Statistik"
- output stats via `[statistik]` shortcode and placeholder
- adjust admin JS for new Statistik table
- update README wording

## Testing
- `php -l players.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650984e2288331b6cb99fc33e8e498