### PR TITLE
UI improvements and ad defaults

### DIFF
--- a/assets/admin-player.css
+++ b/assets/admin-player.css
@@ -4,13 +4,15 @@
 #tab-statistik{overflow-x:auto;}
 #tab-statistik table{width:100%;table-layout:fixed;}
 #tab-statistik input,#tab-statistik select{width:100%;box-sizing:border-box;}
-#tab-radar .mvpclub-radar-flex{display:flex;justify-content:space-between;align-items:flex-start;gap:20px;}
-#tab-radar .mvpclub-radar-settings{flex:1;}
+#tab-radar .mvpclub-radar-flex{display:flex;flex-direction:column;align-items:flex-start;gap:20px;}
+#tab-radar .mvpclub-radar-settings{width:400px;}
 #tab-radar .mvpclub-radar-settings tr{display:flex;align-items:center;gap:8px;}
 #tab-radar .mvpclub-radar-settings td:first-child{flex:1;}
 #tab-radar .mvpclub-radar-settings input[type="text"]{width:100%;}
 #tab-radar .mvpclub-radar-settings input[type="range"]{flex:1;}
 #tab-radar .mvpclub-radar-settings output{width:3em;text-align:right;display:block;}
-#mvpclub-radar-preview{display:block;max-width:250px;margin-left:auto;align-self:flex-start;}
+#mvpclub-radar-preview{display:block;width:400px;max-width:100%;margin:0 0 20px 0;}
 #birthplace_country.mvpclub-emoji-select{width:4em;}
 #birthplace_city{width:21em;}
+.mvpclub-birthdate-wrap{display:flex;align-items:center;width:25em;gap:0.5em;}
+.mvpclub-birthdate-wrap input{width:8em;}

--- a/assets/player-admin.js
+++ b/assets/player-admin.js
@@ -33,11 +33,9 @@ jQuery(function($){
 
     var radarChart;
     function adjustRadarSize(){
-        var settings = $('.mvpclub-radar-settings');
         var canvas = $('#mvpclub-radar-preview');
-        if(settings.length && canvas.length){
-            var h = settings.outerHeight();
-            var size = Math.min(250, h);
+        if(canvas.length){
+            var size = 400;
             canvas.attr('width', size).attr('height', size);
         }
     }

--- a/backend.php
+++ b/backend.php
@@ -107,8 +107,8 @@ function mvpclub_render_ads_settings_page() {
     }
 
     // Aktuelle Werte laden
-    $client = get_option('mvpclub_ads_client', '');
-    $slot   = get_option('mvpclub_ads_slot', '');
+    $client = get_option('mvpclub_ads_client', 'ca-pub-3126572075544456');
+    $slot   = get_option('mvpclub_ads_slot', '8708811170');
 
     ?>
     <div class="wrap">
@@ -135,7 +135,7 @@ function mvpclub_render_ads_settings_page() {
  * Passt das Shortcode-Rendering an, um Client- und Slot-ID zu nutzen.
  */
 add_filter('shortcode_atts_ad', function($out) {
-    $out['client'] = get_option('mvpclub_ads_client', 'ca-pub-XXXX');
-    $out['slot']   = get_option('mvpclub_ads_slot',   'YYYY');
+    $out['client'] = get_option('mvpclub_ads_client', 'ca-pub-3126572075544456');
+    $out['slot']   = get_option('mvpclub_ads_slot',   '8708811170');
     return $out;
 }, 10, 1);

--- a/players.php
+++ b/players.php
@@ -296,7 +296,6 @@ function mvpclub_player_meta_box($post) {
             $age_text = (new DateTime())->diff($d)->y . ' Jahre';
         }
     }
-    echo '<tr><th>Alter</th><td>' . esc_html($age_text) . '</td></tr>';
     foreach ($info_keys as $key) {
         $label = $fields[$key];
         $value = isset($values[$key]) ? $values[$key] : '';
@@ -328,10 +327,16 @@ function mvpclub_player_meta_box($post) {
                 echo '<option value="' . esc_attr($op) . '"' . $sel . '>' . esc_html($op) . '</option>';
             }
             echo '</select></td></tr>';
+        } elseif ($key === 'birthdate') {
+            echo '<tr><th><label for="birthdate">' . esc_html($label) . '</label></th><td>';
+            echo '<div class="mvpclub-birthdate-wrap">';
+            echo '<input type="text" name="birthdate" id="birthdate" value="' . esc_attr($value) . '" class="regular-text" style="width:8em;margin-right:0.5em;" />';
+            echo '<span class="mvpclub-age">' . esc_html($age_text) . '</span>';
+            echo '</div></td></tr>';
         } elseif ($key === 'nationality') {
             $countries = mvpclub_get_country_map();
             echo '<tr><th><label for="nationality">' . esc_html($label) . '</label></th><td>';
-            echo '<select name="nationality" id="nationality">';
+            echo '<select name="nationality" id="nationality" class="regular-text">';
             echo '<option value=""></option>';
             foreach ($countries as $c) {
                 $val = $c['emoji'] . ' ' . $c['name'];
@@ -432,7 +437,7 @@ function mvpclub_player_meta_box($post) {
     echo '<p><button type="button" class="button" id="add-statistik-row">Zeile hinzufügen</button></p></div>';
 
     // Radar Tab
-    echo '<div id="tab-radar" class="mvpclub-tab-content"><div class="mvpclub-radar-flex"><table class="form-table mvpclub-radar-settings">';
+    echo '<div id="tab-radar" class="mvpclub-tab-content"><div class="mvpclub-radar-flex"><canvas id="mvpclub-radar-preview" width="400" height="400"></canvas><table class="form-table mvpclub-radar-settings">';
     $chart = json_decode($values['radar_chart'], true);
     $labels = isset($chart['labels']) ? (array) $chart['labels'] : array_fill(0, 6, '');
     $values_radar = isset($chart['values']) ? (array) $chart['values'] : array_fill(0, 6, 0);
@@ -443,7 +448,7 @@ function mvpclub_player_meta_box($post) {
         echo '<td><input type="range" name="radar_chart_value' . $i . '" min="0" max="100" value="' . esc_attr($v) . '" oninput="this.nextElementSibling.value=this.value" />';
         echo '<output>' . esc_html($v) . '</output></td></tr>';
     }
-    echo '</table><canvas id="mvpclub-radar-preview" width="200" height="200"></canvas></div></div>';
+    echo '</table></div></div>';
 
     echo '</div>'; // end tabs
 }
@@ -503,7 +508,7 @@ add_action('save_post_mvpclub-spieler', function($post_id) {
                 for ($i = 0; $i < $count; $i++) {
                     $row = array(
                         'Saison'     => sanitize_text_field($_POST['perf_saison'][$i]),
-                        'Wettbewerb' => sanitize_text_field(html_entity_decode($_POST['perf_competition'][$i], ENT_QUOTES, 'UTF-8')),
+                        'Wettbewerb' => sanitize_text_field(wp_unslash($_POST['perf_competition'][$i])),
                         'Spiele'     => intval($_POST['perf_games'][$i]),
                         'Tore'       => intval($_POST['perf_goals'][$i]),
                         'Assists'    => intval($_POST['perf_assists'][$i]),

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -26,16 +26,20 @@ add_shortcode('lesedauer', function () {
     return esc_html($minuten . ' Minute' . ($minuten > 1 ? 'n' : '') . ' Lesedauer');
 });
 
-add_shortcode('ad', function() {
+add_shortcode('ad', function($atts = array()) {
+    $atts = shortcode_atts(array(
+        'client' => 'ca-pub-3126572075544456',
+        'slot'   => '8708811170',
+    ), $atts, 'ad');
     ob_start();
     ?>
     <div class="mvpclub-ad">
-        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3126572075544456"
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=<?php echo esc_attr($atts['client']); ?>"
             crossorigin="anonymous"></script>
         <ins class="adsbygoogle"
             style="display:block"
-            data-ad-client="ca-pub-3126572075544456"
-            data-ad-slot="8708811170"
+            data-ad-client="<?php echo esc_attr($atts['client']); ?>"
+            data-ad-slot="<?php echo esc_attr($atts['slot']); ?>"
             data-ad-format="auto"
             data-full-width-responsive="true"></ins>
         <script>


### PR DESCRIPTION
## Summary
- adjust player birthdate field and age display
- widen Nationalität dropdown
- place radar preview above settings
- keep competition emojis when saving
- use options for ad shortcode and provide defaults

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68651f3ac57483319a9d371b7f8ace96