### PR TITLE
Add statistik settings and update scouting block

### DIFF
--- a/assets/editor.css
+++ b/assets/editor.css
@@ -1,0 +1,1 @@
+.mvpclub-player-info{background:none !important;}

--- a/blocks/player-info.js
+++ b/blocks/player-info.js
@@ -7,8 +7,8 @@
     var useSelect = data.useSelect;
 
     registerBlockType('mvpclub/player-info', {
-        title: __('Spielerinfo', 'mvpclub'),
-        icon: 'id',
+        title: __('Scoutingbericht', 'mvpclub'),
+        icon: 'search',
         category: 'mvpclub',
         attributes: {
             playerId: { type: 'integer', default: 0 }

--- a/mvpclub.php
+++ b/mvpclub.php
@@ -3,7 +3,7 @@
 Plugin Name: mvpclub
 Description: Das mvpclub.de Plugin mit Shortcodes, Gutenberg-Blöcken und Admin-Menü.
 Author: Raik Klein
-Version: 3.1.1
+Version: 3.2.0
 */
 
 defined('ABSPATH') || exit;


### PR DESCRIPTION
## Summary
- drop background color from player info block
- rename block to "Scoutingbericht" and use search icon
- add editor stylesheet to remove background in editor
- add Statistik submenu with table styling options and live preview
- style statistik tables based on saved options
- bump plugin version to 3.2.0

## Testing
- `php` not installed, so syntax checks were skipped

------
https://chatgpt.com/codex/tasks/task_e_68652aa0bf788331a19448192716d1c0