### PR TITLE
Fix radar shortcode and improve player admin UX

### DIFF
--- a/assets/player-admin.js
+++ b/assets/player-admin.js
@@ -94,4 +94,9 @@ jQuery(function($){
 
     $(document).on('change', '#birthplace_country', updateBirthplaceSelect);
     updateBirthplaceSelect();
+
+    $(document).on('input', '#height', function(){
+        $(this).next('output').text(this.value + ' cm');
+    });
+    $('#height').trigger('input');
 });

--- a/players.php
+++ b/players.php
@@ -10,6 +10,14 @@ function mvpclub_register_player_cpt() {
         'labels' => array(
             'name'          => 'Spieler',
             'singular_name' => 'Spieler',
+            'add_new'       => 'Spieler hinzufügen',
+            'add_new_item'  => 'Spieler hinzufügen',
+            'edit_item'     => 'Spieler bearbeiten',
+            'new_item'      => 'Neuer Spieler',
+            'view_item'     => 'Spieler ansehen',
+            'search_items'  => 'Spieler durchsuchen',
+            'not_found'     => 'Kein Spieler gefunden',
+            'not_found_in_trash' => 'Kein Spieler im Papierkorb',
         ),
         'public'      => true,
         'has_archive' => false,
@@ -79,6 +87,10 @@ function mvpclub_player_fields() {
         'image'            => 'Bild',
         'radar_chart'      => 'Radar Chart',
     );
+}
+
+function mvpclub_player_info_keys() {
+    return array('image','birthdate','nationality','birthplace','position','detail_position','height','foot','club','market_value');
 }
 
 /**
@@ -214,7 +226,7 @@ function mvpclub_player_placeholders($player_id) {
         '[geburtsdatum]'    => isset($data['birthdate']) ? $data['birthdate'] : '',
         '[geburtsort]'      => isset($data['birthplace']) ? $data['birthplace'] : '',
         '[alter]'           => $age_text,
-        '[groesse]'         => isset($data['height']) ? $data['height'] : '',
+        '[groesse]'         => isset($data['height']) && $data['height'] !== '' ? $data['height'] . ' cm' : '',
         '[nationalitaet]'   => isset($data['nationality']) ? $data['nationality'] : '',
         '[position]'        => isset($data['position']) ? $data['position'] : '',
         '[detailposition]'  => mvpclub_format_detail_position(isset($data['detail_position']) ? $data['detail_position'] : ''),
@@ -445,6 +457,11 @@ function mvpclub_player_meta_box($post) {
             echo '<p><button type="button" class="button mvpclub-player-image-select">Bild auswählen</button> ';
             echo '<button type="button" class="button mvpclub-player-image-remove">Bild entfernen</button></p>';
             echo '</td></tr>';
+        } elseif ($key === 'height') {
+            $val = intval($value) ? intval($value) : 180;
+            echo '<tr><th><label for="height">' . esc_html($label) . '</label></th><td>';
+            echo '<input type="range" name="height" id="height" min="150" max="210" value="' . esc_attr($val) . '" oninput="this.nextElementSibling.value=this.value + \" cm\"" /> ';
+            echo '<output>' . esc_html($val) . ' cm</output></td></tr>';
         } else {
             echo '<tr><th><label for="' . esc_attr($key) . '">' . esc_html($label) . '</label></th>';
             echo '<td><input type="text" name="' . esc_attr($key) . '" id="' . esc_attr($key) . '" value="' . esc_attr($value) . '" class="regular-text" /></td></tr>';
@@ -530,13 +547,22 @@ add_action('save_post_mvpclub-spieler', function($post_id) {
                 delete_post_meta($post_id, 'image');
             }
         } elseif ($key === 'birthplace') {
-            $country = isset($_POST['birthplace_country']) ? wp_unslash($_POST['birthplace_country']) : '';
-            $city = isset($_POST['birthplace_city']) ? sanitize_text_field($_POST['birthplace_city']) : '';
-            $val = trim($country . ' ' . $city);
-            if ($val !== '') {
-                update_post_meta($post_id, 'birthplace', $val);
+            if (isset($_POST['birthplace'])) {
+                $val = sanitize_text_field($_POST['birthplace']);
+                if ($val !== '') {
+                    update_post_meta($post_id, 'birthplace', $val);
+                } else {
+                    delete_post_meta($post_id, 'birthplace');
+                }
             } else {
-                delete_post_meta($post_id, 'birthplace');
+                $country = isset($_POST['birthplace_country']) ? wp_unslash($_POST['birthplace_country']) : '';
+                $city = isset($_POST['birthplace_city']) ? sanitize_text_field($_POST['birthplace_city']) : '';
+                $val = trim($country . ' ' . $city);
+                if ($val !== '') {
+                    update_post_meta($post_id, 'birthplace', $val);
+                } else {
+                    delete_post_meta($post_id, 'birthplace');
+                }
             }
         } elseif ($key === 'detail_position') {
             if (isset($_POST['detail_position']) && is_array($_POST['detail_position'])) {
@@ -908,17 +934,29 @@ function mvpclub_render_statistik_settings_page() {
 /**
  * Add admin columns for player meta fields
  */
-add_filter('manage_mvpclub_player_posts_columns', 'mvpclub_player_admin_columns');
+add_filter('manage_mvpclub-spieler_posts_columns', 'mvpclub_player_admin_columns');
 function mvpclub_player_admin_columns($columns) {
+    $info = mvpclub_player_info_keys();
     $fields = mvpclub_player_fields();
-    foreach ($fields as $key => $label) {
-        $columns[$key] = $label;
+    $new = array();
+    foreach ($columns as $key => $label) {
+        if ($key === 'date') {
+            $new['modified'] = 'Zuletzt Bearbeitet';
+        }
+        $new[$key] = $label;
     }
-    return $columns;
+    foreach ($info as $key) {
+        $new[$key] = isset($fields[$key]) ? $fields[$key] : $key;
+    }
+    return $new;
 }
 
-add_action('manage_mvpclub_player_posts_custom_column', 'mvpclub_player_custom_column', 10, 2);
+add_action('manage_mvpclub-spieler_posts_custom_column', 'mvpclub_player_custom_column', 10, 2);
 function mvpclub_player_custom_column($column, $post_id) {
+    if ($column === 'modified') {
+        echo get_the_modified_date('d.m.Y', $post_id);
+        return;
+    }
     $fields = mvpclub_player_fields();
     if (isset($fields[$column])) {
         if ($column === 'image') {
@@ -934,11 +972,19 @@ function mvpclub_player_custom_column($column, $post_id) {
     }
 }
 
-add_filter('manage_edit-mvpclub_player_sortable_columns', 'mvpclub_player_sortable_columns');
+add_filter('manage_edit-mvpclub-spieler_sortable_columns', 'mvpclub_player_sortable_columns');
 function mvpclub_player_sortable_columns($columns) {
-    $fields = mvpclub_player_fields();
-    foreach ($fields as $key => $label) {
+    $info = mvpclub_player_info_keys();
+    foreach ($info as $key) {
         $columns[$key] = $key;
     }
+    $columns['modified'] = 'modified';
     return $columns;
 }
+
+add_action('pre_get_posts', function($query){
+    if (!is_admin() || !$query->is_main_query()) return;
+    if ($query->get('post_type') === 'mvpclub-spieler' && $query->get('orderby') === 'modified') {
+        $query->set('orderby', 'modified');
+    }
+});

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -76,3 +76,20 @@ add_shortcode('spielstil', function($atts = []) {
     return $val !== '' ? esc_html($val) : '';
 });
 
+add_shortcode('radar', function($atts = []) {
+    $atts = shortcode_atts(['id' => null], $atts);
+    $post_id = $atts['id'] ? intval($atts['id']) : get_the_ID();
+    if (!$post_id) return '';
+    $json = get_post_meta($post_id, 'radar_chart', true);
+    $chart = json_decode($json, true);
+    if (empty($chart['labels']) || empty($chart['values'])) return '';
+    $chart_id = 'radar-chart-' . $post_id . '-' . wp_rand(1, 9999);
+    $chart_src = plugins_url('assets/chart.js', __FILE__);
+    ob_start();
+    ?>
+    <canvas id="<?php echo esc_attr($chart_id); ?>" width="300" height="300"></canvas>
+    <script>(function(){function r(){var c=document.getElementById("<?php echo esc_js($chart_id); ?>");if(!c||typeof Chart==="undefined")return;new Chart(c,{type:"radar",data:{labels:<?php echo wp_json_encode($chart['labels']); ?>,datasets:[{label:"<?php echo esc_js(get_the_title($post_id)); ?>",data:<?php echo wp_json_encode($chart['values']); ?>,backgroundColor:"rgba(54,162,235,0.2)",borderColor:"rgba(54,162,235,1)"}]},options:{scales:{r:{min:0,max:100,beginAtZero:true}}});}if(typeof Chart==="undefined"){var s=document.createElement("script");s.src="<?php echo esc_url($chart_src); ?>";s.onload=r;document.body.appendChild(s);}else{r();}})();</script>
+    <?php
+    return ob_get_clean();
+});
+


### PR DESCRIPTION
## Summary
- register CPT labels for adding/editing a player
- show player height slider and output value with cm suffix
- provide `[radar]` shortcode to render the radar chart
- show last modified date and player info columns in admin list
- support sorting by last modification
- update admin JS to display cm for height slider

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6865367022688331a7d6c4eedf4b406a