### PR TITLE
Implement scouting table styles

### DIFF
--- a/mvpclub.php
+++ b/mvpclub.php
@@ -14,3 +14,13 @@ require_once plugin_dir_path(__FILE__) . 'shortcodes.php';
 require_once plugin_dir_path(__FILE__) . 'fixes.php';
 require_once plugin_dir_path(__FILE__) . 'blocks/scouting-posts.php';
 require_once plugin_dir_path(__FILE__) . 'blocks/ads.php';
+
+// Frontend Styles
+add_action('wp_enqueue_scripts', function() {
+    wp_enqueue_style(
+        'mvpclub-scouting-style',
+        plugins_url('scouting-style.css', __FILE__),
+        array(),
+        filemtime(plugin_dir_path(__FILE__) . 'scouting-style.css')
+    );
+});

--- a/scouting-style.css
+++ b/scouting-style.css
@@ -1,0 +1,21 @@
+.scouting .statistik table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.scouting .statistik th,
+.scouting .statistik td {
+  padding: 12px 16px;
+  border-bottom: 1px solid #eee;
+  text-align: center;
+}
+.scouting .statistik thead th {
+  background-color: #f2f2f2;
+  font-weight: 600;
+}
+.scouting .statistik th:nth-child(2),
+.scouting .statistik td:nth-child(2) {
+  text-align: left;
+}
+.scouting .statistik tbody tr:hover {
+  background-color: #f2f2f2;
+}


### PR DESCRIPTION
## Summary
- add styling for `.scouting .statistik` tables
- enqueue the stylesheet in the plugin

## Testing
- `php -l mvpclub.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68653d19bb908331852a1be63a8ee7eb