### PR TITLE
Add player roles and characteristic shortcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Das **mvpclub.de Plugin** erweitert WordPress um maßgeschneiderte Funktionen f�
 
 ## Funktionen
 
-- ✅ Shortcodes für dynamische Spielerinfos (z. B. Alter, Position, Statistik)
+- ✅ Shortcodes für dynamische Spielerinfos (z. B. Alter, Position, Statistik, Rolle)
 - Neu: Platzhalter `[bild-url]` liefert die Bild-URL eines Spielers
+- Neu: Shortcodes `[staerken]` und `[schwaechen]` geben ProCon-Listen aus
 - 📊 Custom Editor.Blöcke für Scoutingberichte und Spielerstatistiken
 - 🔍 Verbesserte SEO-Auszeichnung mit strukturierten Daten
 - 🧠 Optimiert für datengetriebene Fußballinhalte

--- a/assets/procon.css
+++ b/assets/procon.css
@@ -1,0 +1,2 @@
+.procon{list-style:none;margin:0;padding:0;display:flex;flex-wrap:wrap;gap:8px;}
+.procon li{background:#f2f2f2;border-radius:4px;padding:4px 8px;max-width:100%;}

--- a/mvpclub.php
+++ b/mvpclub.php
@@ -3,7 +3,7 @@
 Plugin Name: mvpclub
 Description: Das mvpclub.de Plugin mit Shortcodes, Gutenberg-Blöcken und Admin-Menü.
 Author: Raik Klein
-Version: 3.2.0
+Version: 3.3.0
 */
 
 defined('ABSPATH') || exit;

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -76,6 +76,44 @@ add_shortcode('spielstil', function($atts = []) {
     return $val !== '' ? esc_html($val) : '';
 });
 
+add_shortcode('rolle', function($atts = []) {
+    $atts = shortcode_atts(['id' => null], $atts);
+    $post_id = $atts['id'] ? intval($atts['id']) : get_the_ID();
+    if (!$post_id) return '';
+    $val = get_post_meta($post_id, 'rolle', true);
+    return $val !== '' ? esc_html($val) : '';
+});
+
+add_shortcode('staerken', function($atts = []) {
+    $atts = shortcode_atts(['id' => null], $atts);
+    $post_id = $atts['id'] ? intval($atts['id']) : get_the_ID();
+    if (!$post_id) return '';
+    $json = get_post_meta($post_id, 'strengths', true);
+    $items = json_decode($json, true);
+    if (!is_array($items) || empty($items)) return '';
+    $out = '<ul class="procon">';
+    foreach ($items as $it) {
+        $out .= '<li>' . esc_html($it) . '</li>';
+    }
+    $out .= '</ul>';
+    return $out;
+});
+
+add_shortcode('schwaechen', function($atts = []) {
+    $atts = shortcode_atts(['id' => null], $atts);
+    $post_id = $atts['id'] ? intval($atts['id']) : get_the_ID();
+    if (!$post_id) return '';
+    $json = get_post_meta($post_id, 'weaknesses', true);
+    $items = json_decode($json, true);
+    if (!is_array($items) || empty($items)) return '';
+    $out = '<ul class="procon">';
+    foreach ($items as $it) {
+        $out .= '<li>' . esc_html($it) . '</li>';
+    }
+    $out .= '</ul>';
+    return $out;
+});
+
 add_shortcode('radar', function($atts = []) {
     $atts = shortcode_atts(['id' => null], $atts);
     $post_id = $atts['id'] ? intval($atts['id']) : get_the_ID();


### PR DESCRIPTION
## Summary
- add role management in scouting settings
- allow assigning a role to a player
- provide `[rolle]`, `[staerken]` and `[schwaechen]` shortcodes
- style procon lists
- bump plugin version to 3.3.0

## Testing
- `php -l players.php` *(fails: command not found)*
- `php -l shortcodes.php` *(fails: command not found)*
- `php -l mvpclub.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686546ea89a48331be69b8ff8f994e97