### PR TITLE
Remove default procon styling

### DIFF
--- a/assets/procon.css
+++ b/assets/procon.css
@@ -1,2 +1,0 @@
-.procon{list-style:none;margin:0;padding:0;display:flex;flex-wrap:wrap;gap:8px;}
-.procon li{background:#f2f2f2;border-radius:4px;padding:4px 8px;max-width:100%;}

--- a/players.php
+++ b/players.php
@@ -1209,12 +1209,5 @@ function mvpclub_player_quick_edit_box($column_name, $post_type) {
     <?php
 }
 
-add_action('wp_enqueue_scripts', function(){
-    wp_enqueue_style(
-        'mvpclub-procon',
-        plugins_url('assets/procon.css', __FILE__),
-        array(),
-        filemtime(plugin_dir_path(__FILE__) . 'assets/procon.css')
-    );
-});
+
 


### PR DESCRIPTION
## Summary
- delete `assets/procon.css`
- stop enqueuing ProCon CSS so only raw `<ul class="procon">` markup remains

## Testing
- `php` not available

------
https://chatgpt.com/codex/tasks/task_e_68655464dd20833195a832fe4ee0dd65