### PR TITLE
Implement numeric attribute management

### DIFF
--- a/assets/player-admin.js
+++ b/assets/player-admin.js
@@ -159,4 +159,30 @@ jQuery(function($){
             });
         };
     }
+
+    // Attribute manager
+    function addAttrRow(group){
+        var table = $('#attr-table-'+group+' tbody');
+        var template = $($('#attr-row-template').html());
+        var next = parseInt(table.data('next')) || 1;
+        template.find('.attr-id').text(next);
+        template.find('.attr-name').attr('name','attr_name['+group+'][0]');
+        var parentSel = template.find('.attr-parent').attr('name','attr_parent['+group+'][0]');
+        // clone parent options
+        var opts = $('#attr-table-'+group+' tbody select:first').find('option').clone();
+        parentSel.empty().append(opts);
+        template.find('.attr-delete').attr('name','attr_delete['+group+'][0]');
+        table.append(template);
+        table.data('next', next + 1);
+    }
+
+    $(document).on('click','.mvpclub-add-attr',function(e){
+        e.preventDefault();
+        addAttrRow($(this).data('group'));
+    });
+
+    $(document).on('click','.mvpclub-delete-attr',function(e){
+        e.preventDefault();
+        $(this).closest('tr').remove();
+    });
 });


### PR DESCRIPTION
## Summary
- manage roles and characteristics with numeric ids
- migrate old options on first load
- render attributes in hierarchical tables
- allow adding, editing and deleting attributes in the UI
- update admin JS for new attribute manager

## Testing
- `php -l players.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68655cc1911c8331a950c3afb7cf6f77