### PR TITLE
Fix attribute selection controls

### DIFF
--- a/assets/player-admin.js
+++ b/assets/player-admin.js
@@ -37,10 +37,10 @@ jQuery(function($){
             var list = window.mvpclubPlayerAdmin.characteristics[type] || [];
             list.forEach(function(item){
                 var optgroup = $('<optgroup>').attr('label', item.main);
-                optgroup.append('<option value="'+item.main+'">'+item.main+'</option>');
+                optgroup.append('<option value="'+item.id+'">'+item.main+'</option>');
                 if(Array.isArray(item.subs)){
                     item.subs.forEach(function(s){
-                        optgroup.append('<option value="'+s+'">'+s+'</option>');
+                        optgroup.append('<option value="'+s.id+'">'+s.name+'</option>');
                     });
                 }
                 select.append(optgroup);

--- a/players.php
+++ b/players.php
@@ -1011,12 +1011,12 @@ function mvpclub_characteristics_section($wrap = false) {
                                 <?php endforeach; ?>
                             </select>
                         </td>
-                        <td><button class="button mvpclub-delete-attr">X</button><input type="hidden" name="attr_delete[<?php echo esc_attr($grp); ?>][<?php echo $id; ?>]" value="" class="attr-delete" /></td>
+                        <td><button type="button" class="button mvpclub-delete-attr">X</button><input type="hidden" name="attr_delete[<?php echo esc_attr($grp); ?>][<?php echo $id; ?>]" value="" class="attr-delete" /></td>
                     </tr>
                 <?php endforeach; ?>
                 </tbody>
             </table>
-            <p><button class="button mvpclub-add-attr" data-group="<?php echo esc_attr($grp); ?>">Hinzufügen</button></p>
+            <p><button type="button" class="button mvpclub-add-attr" data-group="<?php echo esc_attr($grp); ?>">Hinzufügen</button></p>
         <?php endforeach; ?>
         <?php submit_button('Speichern'); ?>
     </form>
@@ -1025,7 +1025,7 @@ function mvpclub_characteristics_section($wrap = false) {
             <td class="attr-id"></td>
             <td><input type="text" class="regular-text attr-name" /></td>
             <td><select class="attr-parent"><option value="0">-</option></select></td>
-            <td><button class="button mvpclub-delete-attr">X</button><input type="hidden" class="attr-delete" /></td>
+            <td><button type="button" class="button mvpclub-delete-attr">X</button><input type="hidden" class="attr-delete" /></td>
         </tr>
     </script>
     <?php


### PR DESCRIPTION
## Summary
- ensure attribute options use IDs instead of objects
- prevent form submission from attribute buttons

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865624c69d883318f03273764550094