### PR TITLE
Fix player table sorting

### DIFF
--- a/players.php
+++ b/players.php
@@ -1353,8 +1353,22 @@ function mvpclub_player_sortable_columns($columns) {
 
 add_action('pre_get_posts', function($query){
     if (!is_admin() || !$query->is_main_query()) return;
-    if ($query->get('post_type') === 'mvpclub-spieler' && $query->get('orderby') === 'modified') {
+    if ($query->get('post_type') !== 'mvpclub-spieler') return;
+
+    $orderby = $query->get('orderby');
+    if ($orderby === 'modified') {
         $query->set('orderby', 'modified');
+        return;
+    }
+
+    $info = mvpclub_player_info_keys();
+    if (in_array($orderby, $info, true)) {
+        $query->set('meta_key', $orderby);
+        if (in_array($orderby, array('height','market_value','rating'), true)) {
+            $query->set('orderby', 'meta_value_num');
+        } else {
+            $query->set('orderby', 'meta_value');
+        }
     }
 });
 


### PR DESCRIPTION
## Summary
- correct sorting for player list columns in admin by hooking `pre_get_posts`

## Testing
- `npm test` *(fails: Could not find package.json)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b7cf296c833187657652bff391dc