### PR TITLE
Add goalkeeper labels for Statistik

### DIFF
--- a/shortcodes.php
+++ b/shortcodes.php
@@ -69,7 +69,8 @@ add_shortcode('statistik', function($atts = []) {
     $post_id = $atts['id'] ? intval($atts['id']) : get_the_ID();
     if (!$post_id) return '';
     $json = get_post_meta($post_id, 'performance_data', true);
-    return mvpclub_generate_statistik_table($json);
+    $pos  = get_post_meta($post_id, 'position', true);
+    return mvpclub_generate_statistik_table($json, $pos);
 });
 
 add_shortcode('spielstil', function($atts = []) {


### PR DESCRIPTION
## Summary
- support goalkeeper-specific Statistik headings
- handle position in shortcodes and placeholders
- allow configuring alternate headers in admin UI

## Testing
- `php -l players.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b7d4a1888331badbfc8eaf431f0b