### PR TITLE
Add rating column in player admin list

### DIFF
--- a/players.php
+++ b/players.php
@@ -95,7 +95,7 @@ function mvpclub_player_fields() {
 }
 
 function mvpclub_player_info_keys() {
-    return array('image','birthdate','nationality','birthplace','position','detail_position','height','foot','club','market_value');
+    return array('image','birthdate','nationality','birthplace','position','detail_position','height','foot','club','market_value','rating');
 }
 
 /**


### PR DESCRIPTION
## Summary
- add `rating` to the list of player info keys

## Testing
- `php -l players.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6868e167585c8331bed7012b383bd1a5