### PR TITLE
Add API-Football integration

### DIFF
--- a/api-football.php
+++ b/api-football.php
@@ -1,0 +1,174 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+function mvpclub_get_api_football_key() {
+    return get_option('mvpclub_api_football_key', '');
+}
+
+function mvpclub_api_football_request($endpoint, $params = array()) {
+    $key = mvpclub_get_api_football_key();
+    if (empty($key)) {
+        return new WP_Error('missing_key', 'API key not set');
+    }
+
+    $url = 'https://v3.football.api-sports.io/' . ltrim($endpoint, '/');
+    if (!empty($params)) {
+        $url = add_query_arg($params, $url);
+    }
+
+    $response = wp_remote_get($url, array(
+        'headers' => array(
+            'x-apisports-key' => $key,
+        ),
+        'timeout' => 15,
+    ));
+
+    if (is_wp_error($response)) {
+        return $response;
+    }
+
+    $code = wp_remote_retrieve_response_code($response);
+    if ($code !== 200) {
+        return new WP_Error('bad_response', 'API request failed', $response);
+    }
+
+    $body = wp_remote_retrieve_body($response);
+    $data = json_decode($body, true);
+    return $data;
+}
+
+function mvpclub_api_football_get_player($player_id, $season = null) {
+    if (!$season) {
+        $season = date('Y');
+    }
+    $data = mvpclub_api_football_request('players', array(
+        'id' => $player_id,
+        'season' => $season,
+    ));
+
+    if (is_wp_error($data)) {
+        return $data;
+    }
+    if (empty($data['response'][0])) {
+        return new WP_Error('not_found', 'Player not found');
+    }
+    return $data['response'][0];
+}
+
+function mvpclub_import_player_post($player_id, $season = null) {
+    $result = mvpclub_api_football_get_player($player_id, $season);
+    if (is_wp_error($result)) {
+        return $result;
+    }
+
+    $player = $result['player'];
+    $stats  = isset($result['statistics'][0]) ? $result['statistics'][0] : array();
+
+    $post_id = wp_insert_post(array(
+        'post_type'   => 'mvpclub-spieler',
+        'post_status' => 'publish',
+        'post_title'  => sanitize_text_field($player['name']),
+    ));
+    if (is_wp_error($post_id)) {
+        return $post_id;
+    }
+
+    $birthdate = '';
+    if (!empty($player['birth']['date'])) {
+        $d = DateTime::createFromFormat('Y-m-d', $player['birth']['date']);
+        if ($d) {
+            $birthdate = $d->format('d.m.Y');
+        }
+    }
+    if ($birthdate) {
+        update_post_meta($post_id, 'birthdate', $birthdate);
+    }
+
+    if (!empty($player['birth']['country']) || !empty($player['birth']['place'])) {
+        $place = trim($player['birth']['country'] . ' ' . $player['birth']['place']);
+        update_post_meta($post_id, 'birthplace', $place);
+    }
+
+    if (!empty($player['nationality'])) {
+        update_post_meta($post_id, 'nationality', $player['nationality']);
+    }
+
+    if (!empty($player['height'])) {
+        if (preg_match('/(\d+)/', $player['height'], $m)) {
+            update_post_meta($post_id, 'height', intval($m[1]));
+        }
+    }
+
+    if (!empty($stats['games']['position'])) {
+        $map = array(
+            'Goalkeeper' => 'Tor',
+            'Defender'   => 'Abwehr',
+            'Midfielder' => 'Mittelfeld',
+            'Attacker'   => 'Sturm',
+        );
+        $position = isset($map[$stats['games']['position']]) ? $map[$stats['games']['position']] : $stats['games']['position'];
+        update_post_meta($post_id, 'position', $position);
+    }
+
+    if (!empty($stats['team']['name'])) {
+        update_post_meta($post_id, 'club', $stats['team']['name']);
+    }
+
+    if (!empty($player['photo'])) {
+        update_post_meta($post_id, 'image_external', esc_url_raw($player['photo']));
+    }
+
+    return $post_id;
+}
+
+if (defined('WP_CLI') && WP_CLI) {
+    WP_CLI::add_command('mvpclub import-player', function($args, $assoc_args) {
+        list($player_id) = $args;
+        $season = isset($assoc_args['season']) ? $assoc_args['season'] : null;
+        $id = mvpclub_import_player_post($player_id, $season);
+        if (is_wp_error($id)) {
+            WP_CLI::error($id->get_error_message());
+        } else {
+            WP_CLI::success('Imported player with post ID ' . $id);
+        }
+    });
+}
+
+add_action('admin_menu', function() {
+    add_submenu_page(
+        'mvpclub-main',
+        'API-FOOTBALL',
+        'API-FOOTBALL',
+        'manage_options',
+        'mvpclub-api-football',
+        'mvpclub_render_api_football_settings_page'
+    );
+});
+
+function mvpclub_render_api_football_settings_page() {
+    if (!current_user_can('manage_options')) {
+        return;
+    }
+
+    if (isset($_POST['mvpclub_api_key']) && check_admin_referer('mvpclub_api_football_save', 'mvpclub_api_football_nonce')) {
+        update_option('mvpclub_api_football_key', sanitize_text_field($_POST['mvpclub_api_key']));
+        echo '<div class="updated"><p>Einstellungen gespeichert.</p></div>';
+    }
+
+    $key = get_option('mvpclub_api_football_key', '');
+    ?>
+    <div class="wrap">
+        <h1>API-FOOTBALL</h1>
+        <form method="post" action="">
+            <?php wp_nonce_field('mvpclub_api_football_save','mvpclub_api_football_nonce'); ?>
+            <table class="form-table">
+                <tr>
+                    <th scope="row"><label for="mvpclub_api_key">API Key</label></th>
+                    <td><input name="mvpclub_api_key" type="text" id="mvpclub_api_key" value="<?php echo esc_attr($key); ?>" class="regular-text" /></td>
+                </tr>
+            </table>
+            <?php submit_button('Speichern'); ?>
+        </form>
+    </div>
+    <?php
+}

--- a/mvpclub.php
+++ b/mvpclub.php
@@ -16,3 +16,4 @@ require_once plugin_dir_path(__FILE__) . 'blocks/scouting-posts.php';
 require_once plugin_dir_path(__FILE__) . 'blocks/ads.php';
 require_once plugin_dir_path(__FILE__) . 'players.php';
 require_once plugin_dir_path(__FILE__) . 'competitions.php';
+require_once plugin_dir_path(__FILE__) . 'api-football.php';


### PR DESCRIPTION
## Summary
- hook up API-Football to fetch player info
- add WP‑CLI command `mvpclub import-player`
- add settings page for API key

## Testing
- `php -v` *(fails: command not found)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6868f4610f5483319a60e5c80b15921b