### PR TITLE
Simplify API‑FOOTBALL player search

### DIFF
--- a/assets/api-football-admin.js
+++ b/assets/api-football-admin.js
@@ -1,31 +1,52 @@
 jQuery(function($){
+    function buildRow(p){
+        var tr = $('<tr>');
+        tr.append('<td>'+p.id+'</td>');
+        tr.append('<td>'+(p.firstname||'')+'</td>');
+        tr.append('<td>'+(p.lastname||'')+'</td>');
+        tr.append('<td>'+(p.age||'')+'</td>');
+        tr.append('<td>'+(p.birth && p.birth.date ? p.birth.date : '')+'</td>');
+        tr.append('<td>'+(p.birth && p.birth.place ? p.birth.place : '')+'</td>');
+        tr.append('<td>'+(p.nationality||'')+'</td>');
+        tr.append('<td>'+(p.height||'')+'</td>');
+        tr.append('<td>'+(p.position||'')+'</td>');
+        var btn = $('<button>').addClass('button mvpclub-add-player').text('Spieler hinzuf\u00fcgen').data('player', p);
+        tr.append($('<td>').append(btn));
+        return tr;
+    }
+
     $('#mvpclub-player-search-form').on('submit', function(e){
         e.preventDefault();
         var query = $(this).find('input[name="player_search"]').val();
-        var league = $(this).find('select[name="search_league"]').val();
         $.post(mvpclubAPIFootball.ajaxUrl, {
             action: 'mvpclub_search_players',
             nonce: mvpclubAPIFootball.nonce,
-            query: query,
-            league: league
+            query: query
         }, function(resp){
             var tbody = $('#mvpclub-search-results tbody');
             tbody.empty();
             if(resp.success && Array.isArray(resp.data)){
                 resp.data.forEach(function(row){
-                    var p = row.player;
-                    var team = row.statistics && row.statistics[0] && row.statistics[0].team ? row.statistics[0].team.name : '';
-                    var link = mvpclubAPIFootball.baseUrl + '&add_player=' + p.id + '&_wpnonce=' + mvpclubAPIFootball.addNonce;
-                    var tr = $('<tr>');
-                    tr.append($('<td>').text($.trim((p.firstname||'')+' '+(p.lastname||p.name))));
-                    tr.append($('<td>').text(team));
-                    tr.append($('<td>').append($('<a>').addClass('button').attr('href', link).text('Spieler hinzuf\u00fcgen')));
-                    tbody.append(tr);
+                    tbody.append(buildRow(row.player));
                 });
-            }else if(resp.data){
-                tbody.append('<tr><td colspan="3">'+resp.data+'</td></tr>');
             }else{
-                tbody.append('<tr><td colspan="3">Keine Ergebnisse</td></tr>');
+                tbody.append('<tr><td colspan="10">'+(resp.data||'Keine Ergebnisse')+'</td></tr>');
+            }
+        }, 'json');
+    });
+
+    $(document).on('click','.mvpclub-add-player', function(e){
+        e.preventDefault();
+        var player = $(this).data('player');
+        $.post(mvpclubAPIFootball.ajaxUrl, {
+            action: 'mvpclub_add_player',
+            nonce: mvpclubAPIFootball.addNonce,
+            player: player
+        }, function(resp){
+            if(resp.success && resp.data && resp.data.edit_link){
+                window.location.href = resp.data.edit_link;
+            }else{
+                alert(resp.data || 'Fehler');
             }
         }, 'json');
     });


### PR DESCRIPTION
## Summary
- simplify the API request for player search to use `players/profiles`
- add helper to create a player post from search data
- create AJAX endpoint for adding players directly from search results
- drop league selector and expand player table columns
- adjust admin JS to use new search and add functionality

## Testing
- `php -l api-football.php`
- `php -l players.php`


------
https://chatgpt.com/codex/tasks/task_e_68692ccaf13c8331948b83b18e951e28