### PR TITLE
Fix API search layout and player import

### DIFF
--- a/api-football.php
+++ b/api-football.php
@@ -195,11 +195,11 @@ function mvpclub_ajax_search_players(){
 add_action('wp_ajax_mvpclub_add_player', 'mvpclub_ajax_add_player');
 function mvpclub_ajax_add_player(){
     check_ajax_referer('mvpclub_add_player', 'nonce');
-    $player = isset($_POST['player']) ? (array) $_POST['player'] : array();
+    $json = isset($_POST['player']) ? wp_unslash($_POST['player']) : '';
+    $player = json_decode($json, true);
     if(empty($player['id'])){
         wp_send_json_error('Missing data');
     }
-    $player = array_map('wp_unslash', $player);
     $id = mvpclub_create_player_post($player);
     if(is_wp_error($id)){
         wp_send_json_error($id->get_error_message());
@@ -305,6 +305,12 @@ function mvpclub_render_api_football_settings_page() {
         </form>
 
         <h2>Ergebnisse</h2>
+        <style>
+            #mvpclub-search-results .mvpclub-add-player{display:block;width:100%;box-sizing:border-box;}
+            #mvpclub-search-pagination{margin-top:10px;}
+            #mvpclub-search-pagination a{margin-right:5px;text-decoration:none;}
+            #mvpclub-search-pagination a.current{font-weight:bold;}
+        </style>
         <table id="mvpclub-search-results" class="widefat fixed striped">
             <thead>
                 <tr>
@@ -342,6 +348,7 @@ function mvpclub_render_api_football_settings_page() {
                 <?php endif; ?>
             </tbody>
         </table>
+        <div id="mvpclub-search-pagination"></div>
     </div>
     <?php
 }

--- a/assets/api-football-admin.js
+++ b/assets/api-football-admin.js
@@ -1,4 +1,6 @@
 jQuery(function($){
+    var results = [], perPage = 10, currentPage = 1;
+
     function buildRow(p){
         var tr = $('<tr>');
         tr.append('<td>'+p.id+'</td>');
@@ -15,6 +17,33 @@ jQuery(function($){
         return tr;
     }
 
+    function render(page){
+        if(page) currentPage = page;
+        var tbody = $('#mvpclub-search-results tbody');
+        tbody.empty();
+        var start = (currentPage-1)*perPage;
+        var slice = results.slice(start, start+perPage);
+        if(slice.length){
+            slice.forEach(function(p){ tbody.append(buildRow(p)); });
+        }else{
+            tbody.append('<tr><td colspan="10">Keine Ergebnisse</td></tr>');
+        }
+        renderPagination();
+    }
+
+    function renderPagination(){
+        var total = Math.ceil(results.length/perPage);
+        var div = $('#mvpclub-search-pagination');
+        div.empty();
+        if(total <= 1) return;
+        for(var i=1;i<=total;i++){
+            var a = $('<a href="#">').text(i).data('page',i);
+            if(i===currentPage) a.addClass('current');
+            div.append(a);
+            if(i<total) div.append(' ');
+        }
+    }
+
     $('#mvpclub-player-search-form').on('submit', function(e){
         e.preventDefault();
         var query = $(this).find('input[name="player_search"]').val();
@@ -23,16 +52,17 @@ jQuery(function($){
             nonce: mvpclubAPIFootball.nonce,
             query: query
         }, function(resp){
-            var tbody = $('#mvpclub-search-results tbody');
-            tbody.empty();
+            results = [];
             if(resp.success && Array.isArray(resp.data)){
-                resp.data.forEach(function(row){
-                    tbody.append(buildRow(row.player));
-                });
-            }else{
-                tbody.append('<tr><td colspan="10">'+(resp.data||'Keine Ergebnisse')+'</td></tr>');
+                resp.data.forEach(function(row){ results.push(row.player); });
             }
+            render(1);
         }, 'json');
+    });
+
+    $(document).on('click','#mvpclub-search-pagination a', function(e){
+        e.preventDefault();
+        render($(this).data('page'));
     });
 
     $(document).on('click','.mvpclub-add-player', function(e){
@@ -41,7 +71,7 @@ jQuery(function($){
         $.post(mvpclubAPIFootball.ajaxUrl, {
             action: 'mvpclub_add_player',
             nonce: mvpclubAPIFootball.addNonce,
-            player: player
+            player: JSON.stringify(player)
         }, function(resp){
             if(resp.success && resp.data && resp.data.edit_link){
                 window.location.href = resp.data.edit_link;

--- a/assets/player-admin.js
+++ b/assets/player-admin.js
@@ -1,12 +1,7 @@
 jQuery(function($){
-    // keep API ID in sync between tabs
-    $('#mvpclub-api-player-id').val($('#api_id').val());
-    $(document).on('input', '#api_id', function(){
-        $('#mvpclub-api-player-id').val($(this).val());
-    });
-    $(document).on('input', '#mvpclub-api-player-id', function(){
-        $('#api_id').val($(this).val());
-    });
+    function getPlayerId(){
+        return $('#api_id').val();
+    }
     function competitionSelect(){
         var select = $('<select name="perf_competition[]">').append('<option value="">-</option>');
         if(window.mvpclubPlayerAdmin && Array.isArray(window.mvpclubPlayerAdmin.competitions)){
@@ -50,7 +45,7 @@ jQuery(function($){
 
 $(document).on('click', '#mvpclub-load-seasons', function(e){
         e.preventDefault();
-        var pid = $('#mvpclub-api-player-id').val();
+        var pid = getPlayerId();
         if(!pid) return;
         $.post(ajaxurl, {
             action: 'mvpclub_load_seasons',
@@ -69,9 +64,9 @@ $(document).on('click', '#mvpclub-load-seasons', function(e){
         }, 'json');
     });
 
-    $(document).on('click', '#mvpclub-load-stats', function(e){
+$(document).on('click', '#mvpclub-load-stats', function(e){
         e.preventDefault();
-        var pid = $('#mvpclub-api-player-id').val();
+        var pid = getPlayerId();
         if(!pid) return;
         var seasons = [];
         $('#statistik-data-table tbody tr').each(function(){

--- a/players.php
+++ b/players.php
@@ -811,8 +811,7 @@ function mvpclub_player_meta_box($post) {
     }
     echo '</tbody></table>';
     echo '<p><button type="button" class="button" id="add-statistik-row">Zeile hinzufügen</button></p>';
-    echo '<p><input type="text" id="mvpclub-api-player-id" placeholder="Player ID" value="' . esc_attr($values['api_id']) . '" /> ';
-    echo '<button type="button" class="button" id="mvpclub-load-seasons">Saisons laden</button> ';
+    echo '<p><button type="button" class="button" id="mvpclub-load-seasons">Saisons laden</button> ';
     echo '<button type="button" class="button" id="mvpclub-load-stats">Daten laden</button></p></div>';
 
     // Radar Tab


### PR DESCRIPTION
## Summary
- style `API-FOOTBALL` search button so the table keeps its width
- paginate search results (10 per page)
- fix AJAX player creation by sending JSON data
- remove duplicate player ID field in Statistik tab
- adjust admin JS to use API tab ID

## Testing
- `php -l api-football.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68692f4506348331a22d168bd74e4fb6