### PR TITLE
Fix API search layout and player import

### DIFF
--- a/assets/player-admin.js
+++ b/assets/player-admin.js
@@ -1,12 +1,7 @@
 jQuery(function($){
-    // keep API ID in sync between tabs
-    $('#mvpclub-api-player-id').val($('#api_id').val());
-    $(document).on('input', '#api_id', function(){
-        $('#mvpclub-api-player-id').val($(this).val());
-    });
-    $(document).on('input', '#mvpclub-api-player-id', function(){
-        $('#api_id').val($(this).val());
-    });
+    function getPlayerId(){
+        return $('#api_id').val();
+    }
     function competitionSelect(){
         var select = $('<select name="perf_competition[]">').append('<option value="">-</option>');
         if(window.mvpclubPlayerAdmin && Array.isArray(window.mvpclubPlayerAdmin.competitions)){
@@ -50,7 +45,7 @@ jQuery(function($){
 
 $(document).on('click', '#mvpclub-load-seasons', function(e){
         e.preventDefault();
-        var pid = $('#mvpclub-api-player-id').val();
+        var pid = getPlayerId();
         if(!pid) return;
         $.post(ajaxurl, {
             action: 'mvpclub_load_seasons',
@@ -69,9 +64,9 @@ $(document).on('click', '#mvpclub-load-seasons', function(e){
         }, 'json');
     });
 
-    $(document).on('click', '#mvpclub-load-stats', function(e){
+$(document).on('click', '#mvpclub-load-stats', function(e){
         e.preventDefault();
-        var pid = $('#mvpclub-api-player-id').val();
+        var pid = getPlayerId();
         if(!pid) return;
         var seasons = [];
         $('#statistik-data-table tbody tr').each(function(){

--- a/players.php
+++ b/players.php
@@ -811,8 +811,7 @@ function mvpclub_player_meta_box($post) {
     }
     echo '</tbody></table>';
     echo '<p><button type="button" class="button" id="add-statistik-row">Zeile hinzufügen</button></p>';
-    echo '<p><input type="text" id="mvpclub-api-player-id" placeholder="Player ID" value="' . esc_attr($values['api_id']) . '" /> ';
-    echo '<button type="button" class="button" id="mvpclub-load-seasons">Saisons laden</button> ';
+    echo '<p><button type="button" class="button" id="mvpclub-load-seasons">Saisons laden</button> ';
     echo '<button type="button" class="button" id="mvpclub-load-stats">Daten laden</button></p></div>';
 
     // Radar Tab


### PR DESCRIPTION
## Summary
- style `API-FOOTBALL` search button so the table keeps its width
- paginate search results (10 per page)
- fix AJAX player creation by sending JSON data
- remove duplicate player ID field in Statistik tab
- adjust admin JS to use API tab ID
- shorten search result button label and properly decode player data

## Testing
- `php -l api-football.php`


------
https://chatgpt.com/codex/tasks/task_e_68692f4506348331a22d168bd74e4fb6