### PR TITLE
Fix API-FOOTBALL player import button

### DIFF
--- a/api-football.php
+++ b/api-football.php
@@ -198,12 +198,15 @@ function mvpclub_ajax_add_player(){
     $raw = isset($_POST['player']) ? $_POST['player'] : '';
     if (is_string($raw)) {
         $player = json_decode(wp_unslash($raw), true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            wp_send_json_error('Ungültige Daten');
+        }
     } elseif (is_array($raw)) {
         $player = array_map('wp_unslash', $raw);
     } else {
         $player = array();
     }
-    if(empty($player['id'])){
+    if (empty($player['id'])) {
         wp_send_json_error('Missing data');
     }
     $id = mvpclub_create_player_post($player);
@@ -240,7 +243,7 @@ add_action('admin_menu', function() {
 
 add_action('admin_enqueue_scripts', 'mvpclub_api_football_admin_scripts');
 function mvpclub_api_football_admin_scripts($hook){
-    if($hook !== 'mvpclub_page_mvpclub-api-football') return;
+    if (strpos($hook, 'mvpclub-api-football') === false) return;
     wp_enqueue_script(
         'mvpclub-api-football-admin',
         plugins_url('assets/api-football-admin.js', __FILE__),
@@ -347,7 +350,7 @@ function mvpclub_render_api_football_settings_page() {
                         <td><?php echo esc_html($p['nationality']); ?></td>
                         <td><?php echo esc_html($p['height']); ?></td>
                         <td><?php echo esc_html($p['position']); ?></td>
-                        <td><button class="button mvpclub-add-player" data-player='<?php echo esc_attr(wp_json_encode($p)); ?>'>Hinzuf&uuml;gen</button></td>
+                        <td><button type="button" class="button mvpclub-add-player" data-id="<?php echo esc_attr($p['id']); ?>" data-player='<?php echo esc_attr(wp_json_encode($p)); ?>'>Hinzuf&uuml;gen</button></td>
                     </tr>
                 <?php endforeach; else: ?>
                     <tr><td colspan="10">Keine Ergebnisse</td></tr>

--- a/assets/api-football-admin.js
+++ b/assets/api-football-admin.js
@@ -12,7 +12,11 @@ jQuery(function($){
         tr.append('<td>'+(p.nationality||'')+'</td>');
         tr.append('<td>'+(p.height||'')+'</td>');
         tr.append('<td>'+(p.position||'')+'</td>');
-        var btn = $('<button>').addClass('button mvpclub-add-player').text('Hinzuf\u00fcgen').data('player', p);
+        var btn = $('<button type="button">')
+            .addClass('button mvpclub-add-player')
+            .text('Hinzuf\u00fcgen')
+            .attr('data-id', p.id)
+            .data('player', p);
         tr.append($('<td>').append(btn));
         return tr;
     }
@@ -67,17 +71,44 @@ jQuery(function($){
 
     $(document).on('click','.mvpclub-add-player', function(e){
         e.preventDefault();
-        var player = $(this).data('player');
+        var btn = $(this);
+        if(btn.prop('disabled')) return;
+        btn.prop('disabled', true);
+        var player = btn.data('player');
+
+        if(!player || typeof player !== 'object'){
+            // Fallback: read from table row if no data attached
+            var tr = btn.closest('tr');
+            player = {
+                id: parseInt(tr.find('td').eq(0).text(), 10),
+                firstname: tr.find('td').eq(1).text(),
+                lastname: tr.find('td').eq(2).text(),
+                age: parseInt(tr.find('td').eq(3).text(), 10) || '',
+                birth: {
+                    date: tr.find('td').eq(4).text(),
+                    place: tr.find('td').eq(5).text()
+                },
+                nationality: tr.find('td').eq(6).text(),
+                height: tr.find('td').eq(7).text(),
+                position: tr.find('td').eq(8).text()
+            };
+        }
+
         $.post(mvpclubAPIFootball.ajaxUrl, {
             action: 'mvpclub_add_player',
             nonce: mvpclubAPIFootball.addNonce,
             player: JSON.stringify(player)
         }, function(resp){
             if(resp.success && resp.data && resp.data.edit_link){
+                alert('Spieler importiert');
                 window.location.href = resp.data.edit_link;
             }else{
-                alert(resp.data || 'Fehler');
+                alert(resp.data || 'Fehler beim Import');
             }
-        }, 'json');
+            btn.prop('disabled', false);
+        }, 'json').fail(function(){
+            alert('Fehler beim Senden der Anfrage');
+            btn.prop('disabled', false);
+        });
     });
 });


### PR DESCRIPTION
## Summary
- load admin script whenever the hook suffix contains `mvpclub-api-football`
- include a player id data attribute for Add Player buttons
- add disabled state and alerts when importing players

## Testing
- `php -l api-football.php` *(fails: command not found)*
- `php -l assets/api-football-admin.js` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686949e835388331ae4f1ed0c2e6afe7