### PR TITLE
Fix seasons order and rename API menu

### DIFF
--- a/api-football.php
+++ b/api-football.php
@@ -233,8 +233,8 @@ if (defined('WP_CLI') && WP_CLI) {
 add_action('admin_menu', function() {
     add_submenu_page(
         'mvpclub-main',
-        'API-FOOTBALL',
-        'API-FOOTBALL',
+        'API',
+        'API',
         'manage_options',
         'mvpclub-api-football',
         'mvpclub_render_api_football_settings_page'
@@ -294,7 +294,7 @@ function mvpclub_render_api_football_settings_page() {
     $key = get_option('mvpclub_api_football_key', '');
     ?>
     <div class="wrap">
-        <h1>API-FOOTBALL</h1>
+        <h1>API</h1>
         <form method="post" action="">
             <?php wp_nonce_field('mvpclub_api_football_save','mvpclub_api_football_nonce'); ?>
             <table class="form-table">

--- a/assets/player-admin.js
+++ b/assets/player-admin.js
@@ -55,7 +55,7 @@ $(document).on('click', '#mvpclub-load-seasons', function(e){
             if(resp.success && Array.isArray(resp.data)){
                 var tbody = $('#statistik-data-table tbody');
                 tbody.empty();
-                resp.data.forEach(function(year){
+                resp.data.slice().reverse().forEach(function(year){
                     addStatistikRow(year);
                 });
             }else if(resp.data){


### PR DESCRIPTION
## Summary
- rename "API-FOOTBALL" menu entry and heading to "API"
- show loaded seasons in reverse order so the newest season is first

## Testing
- `php -l api-football.php` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869546163808331b9e64e84c1a22932