### PR TITLE
Add mvpclub text domain and translate strings

### DIFF
--- a/api-football.php
+++ b/api-football.php
@@ -8,7 +8,7 @@ function mvpclub_get_api_football_key() {
 function mvpclub_api_football_request($endpoint, $params = array()) {
     $key = mvpclub_get_api_football_key();
     if (empty($key)) {
-        return new WP_Error('missing_key', 'API key not set');
+        return new WP_Error('missing_key', __('API key not set', 'mvpclub'));
     }
 
     $url = 'https://v3.football.api-sports.io/' . ltrim($endpoint, '/');
@@ -29,7 +29,7 @@ function mvpclub_api_football_request($endpoint, $params = array()) {
 
     $code = wp_remote_retrieve_response_code($response);
     if ($code !== 200) {
-        return new WP_Error('bad_response', 'API request failed', $response);
+        return new WP_Error('bad_response', __('API request failed', 'mvpclub'), $response);
     }
 
     $body = wp_remote_retrieve_body($response);
@@ -74,7 +74,7 @@ function mvpclub_api_football_get_player($player_id, $season = null) {
         return $data;
     }
     if (empty($data['response'][0])) {
-        return new WP_Error('not_found', 'Player not found');
+        return new WP_Error('not_found', __('Player not found', 'mvpclub'));
     }
     return $data['response'][0];
 }
@@ -150,7 +150,7 @@ function mvpclub_import_player_post($player_id, $season = null) {
         return $profiles;
     }
     if (empty($profiles[0]['player'])) {
-        return new WP_Error('not_found', 'Player not found');
+        return new WP_Error('not_found', __('Player not found', 'mvpclub'));
     }
 
     return mvpclub_create_player_post($profiles[0]['player']);
@@ -199,7 +199,7 @@ function mvpclub_ajax_add_player(){
     if (is_string($raw)) {
         $player = json_decode(wp_unslash($raw), true);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            wp_send_json_error('Ungültige Daten');
+            wp_send_json_error(__('Ungültige Daten', 'mvpclub'));
         }
     } elseif (is_array($raw)) {
         $player = array_map('wp_unslash', $raw);
@@ -207,7 +207,7 @@ function mvpclub_ajax_add_player(){
         $player = array();
     }
     if (empty($player['id'])) {
-        wp_send_json_error('Missing data');
+        wp_send_json_error(__('Missing data', 'mvpclub'));
     }
     $id = mvpclub_create_player_post($player);
     if(is_wp_error($id)){
@@ -233,8 +233,8 @@ if (defined('WP_CLI') && WP_CLI) {
 add_action('admin_menu', function() {
     add_submenu_page(
         'mvpclub-main',
-        'API',
-        'API',
+        __('API', 'mvpclub'),
+        __('API', 'mvpclub'),
         'manage_options',
         'mvpclub-api-football',
         'mvpclub_render_api_football_settings_page'
@@ -265,7 +265,7 @@ function mvpclub_render_api_football_settings_page() {
 
     if (isset($_POST['mvpclub_api_key']) && check_admin_referer('mvpclub_api_football_save', 'mvpclub_api_football_nonce')) {
         update_option('mvpclub_api_football_key', sanitize_text_field($_POST['mvpclub_api_key']));
-        echo '<div class="updated"><p>Einstellungen gespeichert.</p></div>';
+        echo '<div class="updated"><p>' . esc_html__('Einstellungen gespeichert.', 'mvpclub') . '</p></div>';
     }
 
     $import_result = null;
@@ -276,7 +276,7 @@ function mvpclub_render_api_football_settings_page() {
             echo '<div class="error"><p>' . esc_html($import_result->get_error_message()) . '</p></div>';
         } else {
             $edit_link = admin_url('post.php?post=' . $import_result . '&action=edit');
-            echo '<div class="updated"><p>Spieler importiert. <a href="' . esc_url($edit_link) . '">Profil bearbeiten</a></p></div>';
+            echo '<div class="updated"><p>' . sprintf(esc_html__('Spieler importiert. %sProfil bearbeiten%s', 'mvpclub'), '<a href="' . esc_url($edit_link) . '">', '</a>') . '</p></div>';
         }
     }
 
@@ -294,26 +294,26 @@ function mvpclub_render_api_football_settings_page() {
     $key = get_option('mvpclub_api_football_key', '');
     ?>
     <div class="wrap">
-        <h1>API</h1>
+        <h1><?php echo esc_html__('API', 'mvpclub'); ?></h1>
         <form method="post" action="">
             <?php wp_nonce_field('mvpclub_api_football_save','mvpclub_api_football_nonce'); ?>
             <table class="form-table">
                 <tr>
-                    <th scope="row"><label for="mvpclub_api_key">API Key</label></th>
+                    <th scope="row"><label for="mvpclub_api_key"><?php echo esc_html__('API Key', 'mvpclub'); ?></label></th>
                     <td><input name="mvpclub_api_key" type="text" id="mvpclub_api_key" value="<?php echo esc_attr($key); ?>" class="regular-text" /></td>
                 </tr>
             </table>
-            <?php submit_button('Speichern'); ?>
+            <?php submit_button(__('Speichern', 'mvpclub')); ?>
         </form>
 
-        <h2>Spieler suchen</h2>
+        <h2><?php echo esc_html__('Spieler suchen', 'mvpclub'); ?></h2>
         <form id="mvpclub-player-search-form" method="get">
             <input type="hidden" name="page" value="mvpclub-api-football" />
             <input name="player_search" type="text" value="<?php echo esc_attr($player_search); ?>" class="regular-text" />
-            <?php submit_button('Suchen', 'secondary', 'submit', false); ?>
+            <?php submit_button(__('Suchen', 'mvpclub'), 'secondary', 'submit', false); ?>
         </form>
 
-        <h2>Ergebnisse</h2>
+        <h2><?php echo esc_html__('Ergebnisse', 'mvpclub'); ?></h2>
         <style>
             #mvpclub-search-results .mvpclub-add-player{display:block;width:100%;box-sizing:border-box;}
             #mvpclub-search-pagination{margin-top:10px;}
@@ -323,15 +323,15 @@ function mvpclub_render_api_football_settings_page() {
         <table id="mvpclub-search-results" class="widefat fixed striped">
             <thead>
                 <tr>
-                    <th>ID</th>
-                    <th>Vorname</th>
-                    <th>Nachname</th>
-                    <th>Alter</th>
-                    <th>Geburtsdatum</th>
-                    <th>Geburtsort</th>
-                    <th>Nationalit&auml;t</th>
-                    <th>Gr&ouml;&szlig;e</th>
-                    <th>Position</th>
+                    <th><?php echo esc_html__('ID', 'mvpclub'); ?></th>
+                    <th><?php echo esc_html__('Vorname', 'mvpclub'); ?></th>
+                    <th><?php echo esc_html__('Nachname', 'mvpclub'); ?></th>
+                    <th><?php echo esc_html__('Alter', 'mvpclub'); ?></th>
+                    <th><?php echo esc_html__('Geburtsdatum', 'mvpclub'); ?></th>
+                    <th><?php echo esc_html__('Geburtsort', 'mvpclub'); ?></th>
+                    <th><?php echo esc_html__('Nationalität', 'mvpclub'); ?></th>
+                    <th><?php echo esc_html__('Größe', 'mvpclub'); ?></th>
+                    <th><?php echo esc_html__('Position', 'mvpclub'); ?></th>
                     <th></th>
                 </tr>
             </thead>
@@ -350,10 +350,10 @@ function mvpclub_render_api_football_settings_page() {
                         <td><?php echo esc_html($p['nationality']); ?></td>
                         <td><?php echo esc_html($p['height']); ?></td>
                         <td><?php echo esc_html($p['position']); ?></td>
-                        <td><button type="button" class="button mvpclub-add-player" data-id="<?php echo esc_attr($p['id']); ?>" data-player='<?php echo esc_attr(wp_json_encode($p)); ?>'>Hinzuf&uuml;gen</button></td>
+                        <td><button type="button" class="button mvpclub-add-player" data-id="<?php echo esc_attr($p['id']); ?>" data-player='<?php echo esc_attr(wp_json_encode($p)); ?>'><?php echo esc_html__('Hinzufügen', 'mvpclub'); ?></button></td>
                     </tr>
                 <?php endforeach; else: ?>
-                    <tr><td colspan="10">Keine Ergebnisse</td></tr>
+                    <tr><td colspan="10"><?php echo esc_html__('Keine Ergebnisse', 'mvpclub'); ?></td></tr>
                 <?php endif; ?>
             </tbody>
         </table>

--- a/backend.php
+++ b/backend.php
@@ -4,8 +4,8 @@ if (!defined('ABSPATH')) exit;
 // Admin-Menü registrieren
 add_action('admin_menu', function () {
     add_menu_page(
-        'MVP Zentrale',
-        'MVP',
+        __('MVP Zentrale', 'mvpclub'),
+        __('MVP', 'mvpclub'),
         'edit_posts',
         'mvpclub-main',
         'mvpclub_redirect_to_players',
@@ -16,8 +16,8 @@ add_action('admin_menu', function () {
     // Kombinierter Menüpunkt für Blöcke und Shortcodes
     add_submenu_page(
         'mvpclub-main',
-        'Elemente',
-        'Elemente',
+        __('Elemente', 'mvpclub'),
+        __('Elemente', 'mvpclub'),
         'edit_posts',
         'mvpclub-elements',
         'mvpclub_render_elements_page'
@@ -32,36 +32,36 @@ function mvpclub_redirect_to_players() {
 }
 
 function mvpclub_render_block_page() {
-    echo '<div class="wrap"><h1>Scouting-Block</h1><p>Der Gutenberg-Block <code>Scouting Posts</code> ist aktiv.</p></div>';
+    echo '<div class="wrap"><h1>' . esc_html__('Scouting-Block', 'mvpclub') . '</h1><p>' . esc_html__('Der Gutenberg-Block', 'mvpclub') . ' <code>Scouting Posts</code> ' . esc_html__('ist aktiv.', 'mvpclub') . '</p></div>';
 }
 
 function mvpclub_render_shortcodes_page() {
     echo '<div class="wrap">
-        <h1>Shortcodes</h1>
-        <p>Folgende Shortcodes stehen zur Verfügung:</p>
+        <h1>' . esc_html__('Shortcodes', 'mvpclub') . '</h1>
+        <p>' . esc_html__('Folgende Shortcodes stehen zur Verfügung:', 'mvpclub') . '</p>
         <table class="widefat fixed striped" style="width:100%; table-layout:auto;">
             <thead>
                 <tr>
-                    <th>Shortcode</th>
-                    <th>Beschreibung</th>
-                    <th>Beispiel</th>
+                    <th>' . esc_html__('Shortcode', 'mvpclub') . '</th>
+                    <th>' . esc_html__('Beschreibung', 'mvpclub') . '</th>
+                    <th>' . esc_html__('Beispiel', 'mvpclub') . '</th>
                 </tr>
             </thead>
             <tbody>
                 <tr>
                     <td><code>[lesedauer]</code></td>
-                    <td>Zeigt die geschätzte Lesedauer des Beitrags an.</td>
-                    <td><code>5 Minuten</code></td>
+                    <td>' . esc_html__('Zeigt die geschätzte Lesedauer des Beitrags an.', 'mvpclub') . '</td>
+                    <td><code>5 ' . esc_html__('Minuten', 'mvpclub') . '</code></td>
                 </tr>
                 <tr>
                     <td><code>[alter datum="01.01.2000"]</code></td>
-                    <td>Berechnet das aktuelle Alter basierend auf dem angegebenen Datum.</td>
-                    <td><code>24 Jahre</code></td>
+                    <td>' . esc_html__('Berechnet das aktuelle Alter basierend auf dem angegebenen Datum.', 'mvpclub') . '</td>
+                    <td><code>24 ' . esc_html__('Jahre', 'mvpclub') . '</code></td>
                 </tr>
                 <tr>
                     <td><code>[ad]</code></td>
-                    <td>Zeigt eine Google AdSense-Anzeige an.</td>
-                    <td><code>Anzeige wird hier angezeigt.</code></td>
+                    <td>' . esc_html__('Zeigt eine Google AdSense-Anzeige an.', 'mvpclub') . '</td>
+                    <td><code>' . esc_html__('Anzeige wird hier angezeigt.', 'mvpclub') . '</code></td>
                 </tr>
             </tbody>
         </table>
@@ -81,8 +81,8 @@ add_action('admin_menu', function() {
     // „mvpclub-main“ müsste der Slug deines Haupt-Menüs sein
     add_submenu_page(
         'mvpclub-main',
-        'Werbung-Einstellungen',
-        'Werbung',
+        __('Werbung-Einstellungen', 'mvpclub'),
+        __('Werbung', 'mvpclub'),
         'edit_posts', // <-- Hier geändert
         'mvpclub-ads-settings',
         'mvpclub_render_ads_settings_page'
@@ -101,7 +101,7 @@ function mvpclub_render_ads_settings_page() {
     if (isset($_POST['mvpclub_ads_client']) && check_admin_referer('mvpclub_ads_save', 'mvpclub_ads_nonce')) {
         update_option('mvpclub_ads_client', sanitize_text_field($_POST['mvpclub_ads_client']));
         update_option('mvpclub_ads_slot',   sanitize_text_field($_POST['mvpclub_ads_slot']));
-        echo '<div class="updated"><p>Einstellungen gespeichert.</p></div>';
+        echo '<div class="updated"><p>' . esc_html__('Einstellungen gespeichert.', 'mvpclub') . '</p></div>';
     }
 
     // Aktuelle Werte laden
@@ -110,20 +110,20 @@ function mvpclub_render_ads_settings_page() {
 
     ?>
     <div class="wrap">
-      <h1>Werbung-Block konfigurieren</h1>
+      <h1><?php echo esc_html__('Werbung-Block konfigurieren', 'mvpclub'); ?></h1>
       <form method="post" action="">
         <?php wp_nonce_field('mvpclub_ads_save','mvpclub_ads_nonce'); ?>
         <table class="form-table">
           <tr>
-            <th scope="row"><label for="mvpclub_ads_client">AdSense Client-ID</label></th>
+            <th scope="row"><label for="mvpclub_ads_client"><?php echo esc_html__('AdSense Client-ID', 'mvpclub'); ?></label></th>
             <td><input name="mvpclub_ads_client" type="text" id="mvpclub_ads_client" value="<?php echo esc_attr($client); ?>" class="regular-text" /></td>
           </tr>
           <tr>
-            <th scope="row"><label for="mvpclub_ads_slot">AdSense Slot-ID</label></th>
+            <th scope="row"><label for="mvpclub_ads_slot"><?php echo esc_html__('AdSense Slot-ID', 'mvpclub'); ?></label></th>
             <td><input name="mvpclub_ads_slot" type="text" id="mvpclub_ads_slot" value="<?php echo esc_attr($slot); ?>" class="regular-text" /></td>
           </tr>
         </table>
-        <?php submit_button('Speichern'); ?>
+        <?php submit_button(__('Speichern', 'mvpclub')); ?>
       </form>
     </div>
     <?php

--- a/competitions.php
+++ b/competitions.php
@@ -158,7 +158,7 @@ function mvpclub_match_competition_label($league_name, $league_country = '') {
 }
 
 add_action('admin_menu', function(){
-    add_submenu_page('mvpclub-main', 'Wettbewerbe', 'Wettbewerbe', 'edit_posts', 'mvpclub-wettbewerbe', 'mvpclub_render_competitions_page');
+    add_submenu_page('mvpclub-main', __('Wettbewerbe', 'mvpclub'), __('Wettbewerbe', 'mvpclub'), 'edit_posts', 'mvpclub-wettbewerbe', 'mvpclub_render_competitions_page');
 });
 
 function mvpclub_render_competitions_page() {
@@ -194,10 +194,10 @@ function mvpclub_render_competitions_page() {
     mvpclub_sort_competitions($comps);
     ?>
     <div class="wrap">
-        <h1>Wettbewerbe</h1>
+        <h1><?php echo esc_html__('Wettbewerbe', 'mvpclub'); ?></h1>
         <table class="widefat fixed">
             <thead>
-                <tr><th>Nation</th><th>Level</th><th>Name</th><th>Aktion</th></tr>
+                <tr><th><?php echo esc_html__('Nation', 'mvpclub'); ?></th><th><?php echo esc_html__('Level', 'mvpclub'); ?></th><th><?php echo esc_html__('Name', 'mvpclub'); ?></th><th><?php echo esc_html__('Aktion', 'mvpclub'); ?></th></tr>
             </thead>
             <tbody>
                 <?php foreach ($comps as $id => $c): ?>
@@ -210,7 +210,7 @@ function mvpclub_render_competitions_page() {
                             <?php wp_nonce_field('mvpclub_competitions_action','mvpclub_competitions_nonce'); ?>
                             <input type="hidden" name="action" value="delete" />
                             <input type="hidden" name="id" value="<?php echo $id; ?>" />
-                            <?php submit_button('Löschen', 'delete', 'submit', false, array('onclick' => "return confirm('Wirklich löschen?');")); ?>
+                            <?php submit_button(__('Löschen', 'mvpclub'), 'delete', 'submit', false, array('onclick' => "return confirm('" . esc_js(__('Wirklich löschen?', 'mvpclub')) . "');")); ?>
                         </form>
                         <form method="post" style="display:inline-block;">
                             <?php wp_nonce_field('mvpclub_competitions_action','mvpclub_competitions_nonce'); ?>
@@ -227,7 +227,7 @@ function mvpclub_render_competitions_page() {
                                 <?php endforeach; ?>
                             </select>
                             <input type="text" name="name" value="<?php echo esc_attr($c['name']); ?>" />
-                            <?php submit_button('Speichern', 'primary', 'submit', false); ?>
+                            <?php submit_button(__('Speichern', 'mvpclub'), 'primary', 'submit', false); ?>
                         </form>
                     </td>
                 </tr>
@@ -251,7 +251,7 @@ function mvpclub_render_competitions_page() {
                             </select>
                         </td>
                         <td><input type="text" name="name" /></td>
-                        <td><?php submit_button('Hinzufügen', 'primary', 'submit', false); ?></td>
+                        <td><?php submit_button(__('Hinzufügen', 'mvpclub'), 'primary', 'submit', false); ?></td>
                     </form>
                 </tr>
             </tbody>

--- a/mvpclub.php
+++ b/mvpclub.php
@@ -4,6 +4,7 @@ Plugin Name: mvpclub
 Description: Das mvpclub.de Plugin mit Shortcodes, Gutenberg-Blöcken und Admin-Menü.
 Author: Raik Klein
 Version: 3.3.0
+Text Domain: mvpclub
 */
 
 defined('ABSPATH') || exit;

--- a/players.php
+++ b/players.php
@@ -8,16 +8,16 @@ add_action('init', 'mvpclub_register_player_cpt');
 function mvpclub_register_player_cpt() {
     register_post_type('mvpclub-spieler', array(
         'labels' => array(
-            'name'          => 'Spieler',
-            'singular_name' => 'Spieler',
-            'add_new'       => 'Spieler hinzufügen',
-            'add_new_item'  => 'Spieler hinzufügen',
-            'edit_item'     => 'Spieler bearbeiten',
-            'new_item'      => 'Neuer Spieler',
-            'view_item'     => 'Spieler ansehen',
-            'search_items'  => 'Spieler durchsuchen',
-            'not_found'     => 'Kein Spieler gefunden',
-            'not_found_in_trash' => 'Kein Spieler im Papierkorb',
+            'name'          => __('Spieler', 'mvpclub'),
+            'singular_name' => __('Spieler', 'mvpclub'),
+            'add_new'       => __('Spieler hinzufügen', 'mvpclub'),
+            'add_new_item'  => __('Spieler hinzufügen', 'mvpclub'),
+            'edit_item'     => __('Spieler bearbeiten', 'mvpclub'),
+            'new_item'      => __('Neuer Spieler', 'mvpclub'),
+            'view_item'     => __('Spieler ansehen', 'mvpclub'),
+            'search_items'  => __('Spieler durchsuchen', 'mvpclub'),
+            'not_found'     => __('Kein Spieler gefunden', 'mvpclub'),
+            'not_found_in_trash' => __('Kein Spieler im Papierkorb', 'mvpclub'),
         ),
         'public'      => false,
         'publicly_queryable' => false,
@@ -74,24 +74,24 @@ function mvpclub_migrate_player_cpt() {
  */
 function mvpclub_player_fields() {
     return array(
-        'birthdate'        => 'Geburtsdatum',
-        'birthplace'       => 'Geburtsort',
-        'height'           => 'Größe',
-        'nationality'      => 'Nationalität',
-        'position'         => 'Position',
-        'detail_position'  => 'Detailposition',
-        'foot'             => 'Fuß',
-        'club'             => 'Verein',
-        'market_value'     => 'Marktwert',
-        'rating'           => 'Bewertung',
-        'spielstil'        => 'Spielstil',
-        'rolle'            => 'Rolle',
-        'strengths'        => 'Stärken',
-        'weaknesses'       => 'Schwächen',
-        'performance_data' => 'Statistik',
-        'image'            => 'Bild',
-        'radar_chart'      => 'Radar Chart',
-        'api_id'           => 'ID',
+        'birthdate'        => __('Geburtsdatum', 'mvpclub'),
+        'birthplace'       => __('Geburtsort', 'mvpclub'),
+        'height'           => __('Größe', 'mvpclub'),
+        'nationality'      => __('Nationalität', 'mvpclub'),
+        'position'         => __('Position', 'mvpclub'),
+        'detail_position'  => __('Detailposition', 'mvpclub'),
+        'foot'             => __('Fuß', 'mvpclub'),
+        'club'             => __('Verein', 'mvpclub'),
+        'market_value'     => __('Marktwert', 'mvpclub'),
+        'rating'           => __('Bewertung', 'mvpclub'),
+        'spielstil'        => __('Spielstil', 'mvpclub'),
+        'rolle'            => __('Rolle', 'mvpclub'),
+        'strengths'        => __('Stärken', 'mvpclub'),
+        'weaknesses'       => __('Schwächen', 'mvpclub'),
+        'performance_data' => __('Statistik', 'mvpclub'),
+        'image'            => __('Bild', 'mvpclub'),
+        'radar_chart'      => __('Radar Chart', 'mvpclub'),
+        'api_id'           => __('ID', 'mvpclub'),
     );
 }
 
@@ -756,14 +756,14 @@ function mvpclub_player_meta_box($post) {
     foreach ($strengths as $s) {
         echo '<li>' . mvpclub_characteristic_select($type, 'strengths[]', $s) . ' <button type="button" class="button remove-characteristic">X</button></li>';
     }
-    echo '</ul><p><button type="button" class="button" id="add-strength">Hinzufügen</button></p></td></tr>';
+    echo '</ul><p><button type="button" class="button" id="add-strength">' . esc_html__('Hinzufügen', 'mvpclub') . '</button></p></td></tr>';
 
     echo '<tr><th><label>Schwächen</label></th><td>';
     echo '<ul id="mvpclub-weaknesses-list" class="mvpclub-characteristic-list">';
     foreach ($weaknesses as $w) {
         echo '<li>' . mvpclub_characteristic_select($type, 'weaknesses[]', $w) . ' <button type="button" class="button remove-characteristic">X</button></li>';
     }
-    echo '</ul><p><button type="button" class="button" id="add-weakness">Hinzufügen</button></p></td></tr>';
+    echo '</ul><p><button type="button" class="button" id="add-weakness">' . esc_html__('Hinzufügen', 'mvpclub') . '</button></p></td></tr>';
 
     echo '</table></div>';
 
@@ -997,7 +997,7 @@ function mvpclub_render_scout_settings_page() {
                     <button type="button" class="insert-placeholder button" data-placeholder="<?php echo esc_attr($tag); ?>"><?php echo esc_html($tag); ?></button>
                 <?php endforeach; ?>
             </p>
-            <?php submit_button('Speichern'); ?>
+            <?php submit_button(__('Speichern', 'mvpclub')); ?>
         </form>
 
         <h2>Vorschau <select id="mvpclub_preview_player" style="float:right;">
@@ -1095,9 +1095,9 @@ function mvpclub_characteristics_section($wrap = false) {
                 <?php endforeach; ?>
                 </tbody>
             </table>
-            <p><button type="button" class="button mvpclub-add-attr" data-group="<?php echo esc_attr($grp); ?>">Hinzufügen</button></p>
+            <p><button type="button" class="button mvpclub-add-attr" data-group="<?php echo esc_attr($grp); ?>"><?php echo esc_html__('Hinzufügen', 'mvpclub'); ?></button></p>
         <?php endforeach; ?>
-        <?php submit_button('Speichern'); ?>
+        <?php submit_button(__('Speichern', 'mvpclub')); ?>
     </form>
     <script type="text/template" id="attr-row-template">
         <tr>
@@ -1402,7 +1402,7 @@ function mvpclub_render_statistik_settings_page() {
                     </td>
                 </tr>
             </table>
-            <?php submit_button('Speichern'); ?>
+            <?php submit_button(__('Speichern', 'mvpclub')); ?>
         </form>
 
         <h2>Live-Vorschau</h2>

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -15,7 +15,8 @@ add_shortcode('alter', function ($atts, $content = null) {
     if (!$geburt) return '';
 
     $heute = new DateTime();
-    return esc_html($heute->diff($geburt)->y . ' Jahre');
+    $years = $heute->diff($geburt)->y;
+    return esc_html(sprintf(__('%d Jahre', 'mvpclub'), $years));
 });
 
 add_shortcode('lesedauer', function () {
@@ -23,7 +24,7 @@ add_shortcode('lesedauer', function () {
     if (!$post || empty($post->post_content)) return '';
     $text = strip_tags($post->post_content);
     $minuten = ceil(str_word_count($text) / 200);
-    return esc_html($minuten . ' Minute' . ($minuten > 1 ? 'n' : '') . ' Lesedauer');
+    return esc_html(sprintf(_n('%d Minute Lesedauer', '%d Minuten Lesedauer', $minuten, 'mvpclub'), $minuten));
 });
 
 add_shortcode('ad', function($atts = array()) {


### PR DESCRIPTION
## Summary
- declare text domain in plugin header
- wrap user-facing strings in translation helpers across PHP files

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68695abc232c8331a39109553df579a0